### PR TITLE
pass cf ci system envs to react app buildscript

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build && npm run sentry:sourcemaps",
+    "build": "REACT_APP_COMMIT_SHA=$CF_PAGES_COMMIT_SHA REACT_APP_VERSION=$npm_package_version react-scripts build && npm run sentry:sourcemaps",
     "test": "eslint . && jest",
     "test:update": "eslint . && jest --updateSnapshot",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org pillar-project --project x ./build && sentry-cli sourcemaps upload --org pillar-project --project x ./build"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,10 +3,13 @@ import ReactDOM from 'react-dom/client';
 import { Buffer as ImportedBuffer } from 'buffer';
 import * as Sentry from '@sentry/react';
 
-const sentryReleaseTag = 'pillarx@'
-  +  process.env.npm_package_version
-  // CF_PAGES_COMMIT_SHA is provided by Cloudfare, in case of provider replacement change it too
-  + (process.env.CF_PAGES_COMMIT_SHA ? '-' + process.env.CF_PAGES_COMMIT_SHA : '');
+let sentryReleaseTag;
+
+// add a release tag only if REACT_APP_VERSION provided
+if (process.env.REACT_APP_VERSION) {
+  sentryReleaseTag = 'pillarx@' + process.env.REACT_APP_VERSION
+    + (process.env.REACT_APP_COMMIT_SHA ? '-' + process.env.REACT_APP_COMMIT_SHA : '');
+}
 
 Sentry.init({
   dsn: process.env.REACT_APP_SENTRY_DSN,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- System envs are not picked on buildscript, pass it on to to React app on `build` command.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested locally on private repo set to deploy on Cloudfare.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
