### PR TITLE
updated privy and txkit deps, added logout, enabled testnets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pillarx",
-  "version": "0.1.11",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pillarx",
-      "version": "0.1.11",
+      "version": "0.2.10",
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "pillarx",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pillarx",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
-        "@etherspot/transaction-kit": "^0.6.9",
+        "@etherspot/transaction-kit": "^0.7.0",
         "@mui/joy": "^5.0.0-beta.22",
-        "@privy-io/react-auth": "^1.50.0",
+        "@privy-io/react-auth": "^1.54.3",
         "@react-spring/web": "^9.7.3",
         "@sentry/cli": "^2.21.5",
         "@sentry/react": "^7.81.1",
@@ -30,6 +30,7 @@
         "react-scripts": "5.0.1",
         "react-transition-group": "^4.4.5",
         "styled-components": "^6.1.1",
+        "viem": "^2.6.1",
         "webfontloader": "^1.6.28"
       },
       "devDependencies": {
@@ -3616,16 +3617,15 @@
       "license": "0BSD"
     },
     "node_modules/@etherspot/transaction-kit": {
-      "version": "0.6.9",
-      "license": "MIT",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@etherspot/transaction-kit/-/transaction-kit-0.7.0.tgz",
+      "integrity": "sha512-LjJHD3vtEx97yuAmNzC7tuJ0EQmhvjZKXUWGSR1bu10WFtnXM2V0nplOk3CwVcwtYMihHyKmOYUBPvfeNzcWiw==",
       "dependencies": {
-        "@etherspot/eip1271-verification-util": "^0.1.2",
-        "@etherspot/prime-sdk": "^1.3.10",
+        "@etherspot/eip1271-verification-util": "0.1.2",
+        "@etherspot/prime-sdk": "1.3.12",
         "buffer": "^6.0.3",
         "ethers": "^5.6.9",
-        "lodash": "^4.17.21",
-        "reflect-metadata": "^0.1.13",
-        "rxjs": "^6.6.7"
+        "lodash": "^4.17.21"
       },
       "peerDependencies": {
         "react": ">=16.13.0"
@@ -4809,6 +4809,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/@headlessui/react": {
+      "version": "1.7.18",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.18.tgz",
+      "integrity": "sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==",
+      "dependencies": {
+        "@tanstack/react-virtual": "^3.0.0-beta.60",
+        "client-only": "^0.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
     "node_modules/@heroicons/react": {
       "version": "2.0.18",
       "license": "MIT",
@@ -5757,8 +5773,9 @@
       }
     },
     "node_modules/@marsidev/react-turnstile": {
-      "version": "0.3.2",
-      "license": "MIT",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@marsidev/react-turnstile/-/react-turnstile-0.4.1.tgz",
+      "integrity": "sha512-uZusUW9mPr0csWpls8bApe5iuRK0YK7H1PCKqfM4djW3OA9GB9rU68irjk7xRO8qlHyj0aDTeVu9tTLPExBO4Q==",
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
@@ -6423,9 +6440,9 @@
       }
     },
     "node_modules/@privy-io/react-auth": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-1.50.0.tgz",
-      "integrity": "sha512-ZdBMP/vadBA34k0yfZZZV9NV1JC1fXz3sGbA6+zoBfitvkfPZL54Y3RjgeK/OwutRu0GB+iWl+TFPCaKVKyu4A==",
+      "version": "1.54.3",
+      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-1.54.3.tgz",
+      "integrity": "sha512-Wxp+RRvGaG6U2FSPTyxji95l8DU+7FY38JCLGC6BSzmnD0xwDR2QFxpQdt9pftYyhd/UcCY89MU9DiGWPc+mUQ==",
       "dependencies": {
         "@coinbase/wallet-sdk": "^3.9.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -6438,13 +6455,13 @@
         "@ethersproject/strings": "^5.7.0",
         "@ethersproject/transactions": "^5.7.0",
         "@ethersproject/units": "^5.7.0",
+        "@headlessui/react": "^1.7.18",
         "@heroicons/react": "^2.0.18",
-        "@marsidev/react-turnstile": "^0.3.2",
+        "@marsidev/react-turnstile": "^0.4.1",
         "@metamask/eth-sig-util": "^6.0.0",
         "@walletconnect/ethereum-provider": "^2.10.5",
         "@walletconnect/modal": "^2.6.2",
         "base64-js": "^1.5.1",
-        "body-scroll-lock": "^4.0.0-beta.0",
         "dotenv": "^16.0.3",
         "encoding": "^0.1.13",
         "eventemitter3": "^5.0.1",
@@ -6459,13 +6476,13 @@
         "pino-pretty": "^10.0.0",
         "qrcode": "^1.5.1",
         "react-device-detect": "^2.2.2",
+        "react-use": "^17.4.2",
         "secure-password-utilities": "^0.2.1",
         "styled-components": "^5.3.6",
         "tinycolor2": "^1.6.0",
         "uuid": ">=8 <10",
         "web3-core": "^1.8.0",
-        "web3-core-helpers": "^1.8.0",
-        "wicg-inert": "^3.1.2"
+        "web3-core-helpers": "^1.8.0"
       },
       "peerDependencies": {
         "react": "^18",
@@ -7230,6 +7247,31 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.2.tgz",
+      "integrity": "sha512-9XbRLPKgnhMwwmuQMnJMv+5a9sitGNCSEtf/AZXzmJdesYk7XsjYHaEDny+IrJzvPNwZliIIDwCRiaUqR3zzCA==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0.tgz",
+      "integrity": "sha512-SYXOBTjJb05rXa2vl55TTwO40A6wKu0R5i1qQwhJYNDIqaIGF7D0HsLw+pJAyi2OvntlEIVusx3xtbbgSUi6zg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "9.3.4",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
@@ -7569,6 +7611,11 @@
       "version": "18.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
@@ -8563,6 +8610,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "license": "BSD-3-Clause"
@@ -8576,18 +8628,15 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/abitype": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
-      "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
-        }
-      ],
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.0.tgz",
+      "integrity": "sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
       "peerDependencies": {
         "typescript": ">=5.0.4",
-        "zod": "^3 >=3.19.1"
+        "zod": "^3 >=3.22.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -9636,10 +9685,6 @@
       "version": "2.0.0",
       "license": "MIT"
     },
-    "node_modules/body-scroll-lock": {
-      "version": "4.0.0-beta.0",
-      "license": "MIT"
-    },
     "node_modules/bonjour-service": {
       "version": "1.1.1",
       "license": "MIT",
@@ -9996,6 +10041,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
     "node_modules/clipboardy": {
       "version": "3.0.0",
       "license": "MIT",
@@ -10272,6 +10322,14 @@
       "version": "1.0.6",
       "license": "MIT"
     },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.33.2",
       "hasInstallScript": true,
@@ -10479,6 +10537,14 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/css-in-js-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.3"
       }
     },
     "node_modules/css-loader": {
@@ -12770,6 +12836,11 @@
       "version": "2.0.6",
       "license": "MIT"
     },
+    "node_modules/fast-loops": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.3.tgz",
+      "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g=="
+    },
     "node_modules/fast-password-entropy": {
       "version": "1.1.1",
       "license": "MIT"
@@ -12784,6 +12855,16 @@
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "license": "MIT"
+    },
+    "node_modules/fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "node_modules/fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -13858,6 +13939,11 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "node_modules/i18next": {
       "version": "23.7.6",
       "funding": [
@@ -14011,6 +14097,15 @@
     "node_modules/ini": {
       "version": "1.3.8",
       "license": "ISC"
+    },
+    "node_modules/inline-style-prefixer": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.0.tgz",
+      "integrity": "sha512-I7GEdScunP1dQ6IM2mQWh6v0mOYdYmH3Bp31UecKdrcUgcURTcctSe1IECdUznSHKSmsHtjrT3CwCPI1pyxfUQ==",
+      "dependencies": {
+        "css-in-js-utils": "^3.1.0",
+        "fast-loops": "^1.1.3"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.6",
@@ -17402,6 +17497,91 @@
         }
       }
     },
+    "node_modules/mipd/node_modules/@scure/bip32": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
+      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
+      "dependencies": {
+        "@noble/curves": "~1.2.0",
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/mipd/node_modules/abitype": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
+      "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.19.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mipd/node_modules/viem": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-1.21.4.tgz",
+      "integrity": "sha512-BNVYdSaUjeS2zKQgPs+49e5JKocfo60Ib2yiXOWBT6LuVxY1I/6fFX3waEtpXvL1Xn4qu+BVitVtMh9lyThyhQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@scure/bip32": "1.3.2",
+        "@scure/bip39": "1.2.1",
+        "abitype": "0.9.8",
+        "isows": "1.0.3",
+        "ws": "8.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mipd/node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "license": "MIT",
@@ -17467,6 +17647,50 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nano-css": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.6.1.tgz",
+      "integrity": "sha512-T2Mhc//CepkTa3X4pUhKgbEheJHYAxD0VptuqFhDbGMUWVV2m+lkNiW/Ieuj35wrfC8Zm0l7HvssQh7zcEttSw==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "css-tree": "^1.1.2",
+        "csstype": "^3.1.2",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^7.0.0",
+        "rtl-css-js": "^1.16.1",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.3.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/nano-css/node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/nano-css/node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
+    "node_modules/nano-css/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/nanoid": {
@@ -21355,6 +21579,45 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
+      "peerDependencies": {
+        "react": "*",
+        "tslib": "*"
+      }
+    },
+    "node_modules/react-use": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.5.0.tgz",
+      "integrity": "sha512-PbfwSPMwp/hoL847rLnm/qkjg3sTRCvn6YhUZiHaUa3FA6/aNoFX79ul5Xt70O1rK+9GxSVqkY0eTwMdsR/bWg==",
+      "dependencies": {
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.6.1",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.1.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^3.0.1",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/react-use/node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "license": "MIT",
@@ -21567,6 +21830,11 @@
       "version": "1.0.0",
       "license": "MIT"
     },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "license": "MIT",
@@ -21757,6 +22025,14 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "funding": [
@@ -21925,6 +22201,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/scrypt-js": {
@@ -22129,6 +22416,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==",
+      "engines": {
+        "node": ">=6.9"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "license": "ISC"
@@ -22320,6 +22615,14 @@
       "version": "0.1.8",
       "license": "MIT"
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "license": "MIT",
@@ -22340,6 +22643,33 @@
     "node_modules/stackframe": {
       "version": "1.3.4",
       "license": "MIT"
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
@@ -23149,6 +23479,14 @@
       "version": "6.0.2",
       "license": "MIT"
     },
+    "node_modules/throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "license": "MIT"
@@ -23177,6 +23515,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -23230,6 +23573,11 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
@@ -23876,9 +24224,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-1.19.11.tgz",
-      "integrity": "sha512-dbsXEWDBZkByuzJXAs/e01j7dpUJ5ICF5WcyntFwf8Y97n5vnC/91lAleSa6DA5V4WJvYZbhDpYeTctsMAQnhA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.6.1.tgz",
+      "integrity": "sha512-565cKS2fQ8XU9sfQo5NGAZXdKwPFjof4nO3NUyElVHKqKw9l5/y2iDDMEubvxm09rBlzibJ+Sw/mI4jnnkQE4g==",
       "funding": [
         {
           "type": "github",
@@ -23891,7 +24239,7 @@
         "@noble/hashes": "1.3.2",
         "@scure/bip32": "1.3.2",
         "@scure/bip39": "1.2.1",
-        "abitype": "0.9.8",
+        "abitype": "1.0.0",
         "isows": "1.0.3",
         "ws": "8.13.0"
       },
@@ -24650,10 +24998,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/wicg-inert": {
-      "version": "3.1.2",
-      "license": "W3C-20150513"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pillarx",
-  "version": "0.1.11",
+  "version": "0.2.10",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pillarx",
-  "version": "0.2.10",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pillarx",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "scripts": {
     "start": "react-scripts start",
@@ -12,9 +12,9 @@
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
-    "@etherspot/transaction-kit": "^0.6.9",
+    "@etherspot/transaction-kit": "^0.7.0",
     "@mui/joy": "^5.0.0-beta.22",
-    "@privy-io/react-auth": "^1.50.0",
+    "@privy-io/react-auth": "^1.54.3",
     "@react-spring/web": "^9.7.3",
     "@sentry/cli": "^2.21.5",
     "@sentry/react": "^7.81.1",
@@ -32,6 +32,7 @@
     "react-scripts": "5.0.1",
     "react-transition-group": "^4.4.5",
     "styled-components": "^6.1.1",
+    "viem": "^2.6.1",
     "webfontloader": "^1.6.28"
   },
   "devDependencies": {

--- a/src/components/BottomMenu/__snapshots__/BottomMenu.test.tsx.snap
+++ b/src/components/BottomMenu/__snapshots__/BottomMenu.test.tsx.snap
@@ -159,18 +159,43 @@ exports[`<BottomMenu /> renders correctly 1`] = `
   outline: none;
 }
 
+.c22 {
+  font-size: 18px;
+  font-weight: 700;
+  padding: 15px 45px;
+  border: none;
+  border-radius: 100px;
+  background: #D9D9D9;
+  color: #1D1D1D;
+  transition: all 0.2s ease-in-out;
+  margin-bottom: 15px;
+  cursor: pointer;
+}
+
+.c22:hover {
+  opacity: 0.7;
+}
+
+.c22:active {
+  opacity: 0.4;
+}
+
+.c22:focus {
+  outline: none;
+}
+
 .c17 {
   font-size: 14px;
   font-weight: 400;
 }
 
-.c25 {
+.c26 {
   display: none;
   max-width: 100%;
   border-radius: 20px;
 }
 
-.c24 {
+.c25 {
   animation: hLhBjP 1s linear infinite alternate;
   height: 100%;
   border-radius: 20px;
@@ -314,7 +339,7 @@ exports[`<BottomMenu /> renders correctly 1`] = `
   text-align: center;
 }
 
-.c22 {
+.c23 {
   display: flex;
   gap: 15px;
   flex-direction: row;
@@ -325,7 +350,7 @@ exports[`<BottomMenu /> renders correctly 1`] = `
   min-height: 100%;
 }
 
-.c23 {
+.c24 {
   width: 90px;
   height: 90px;
   border-radius: 20px;
@@ -334,7 +359,7 @@ exports[`<BottomMenu /> renders correctly 1`] = `
   cursor: pointer;
 }
 
-.c23:hover {
+.c24:hover {
   transform: scale(1.1);
   opacity: 0.9;
 }
@@ -607,6 +632,14 @@ exports[`<BottomMenu /> renders correctly 1`] = `
                 className=""
               >
                 0x7F30B1960D5556929B03a0339814fE903c55a347
+                <br />
+                <br />
+                <button
+                  className="c22"
+                  onClick={[MockFunction]}
+                >
+                  Logout
+                </button>
               </p>
             </div>
           </div>
@@ -618,29 +651,29 @@ exports[`<BottomMenu /> renders correctly 1`] = `
             className="c4"
           >
             <div
-              className="c22"
+              className="c23"
             >
               <div
-                className="c23"
+                className="c24"
                 onClick={[Function]}
               >
                 <div
-                  className="c24"
+                  className="c25"
                 />
                 <img
-                  className="c25"
+                  className="c26"
                   src="icon.png"
                 />
               </div>
               <div
-                className="c23"
+                className="c24"
                 onClick={[Function]}
               >
                 <div
-                  className="c24"
+                  className="c25"
                 />
                 <img
-                  className="c25"
+                  className="c26"
                   src="icon.png"
                 />
               </div>

--- a/src/components/BottomMenuModal/AccountModal.tsx
+++ b/src/components/BottomMenuModal/AccountModal.tsx
@@ -1,15 +1,22 @@
 import { useWalletAddress } from '@etherspot/transaction-kit';
 import styled from 'styled-components';
+import { useLogout } from '@privy-io/react-auth';
+import { useTranslation } from 'react-i18next';
 
 // components
 import Paragraph from '../Text/Paragraph';
+import Button from '../Button';
 
 const AccountModal = () => {
   const walletAddress = useWalletAddress();
+  const { logout } = useLogout();
+  const [t] = useTranslation();
+
   return (
     <Wrapper>
       <Paragraph>
-        {walletAddress}
+        {walletAddress}<br/><br/>
+        <Button onClick={logout}>{t`action.logout`}</Button>
       </Paragraph>
     </Wrapper>
   )

--- a/src/components/BottomMenuModal/SendModal/SendModal.test.tsx
+++ b/src/components/BottomMenuModal/SendModal/SendModal.test.tsx
@@ -145,6 +145,10 @@ describe('<BottomMenu />', () => {
       batches: [],
       estimate: async () => [],
       send: async () => [{ sentBatches: [{ errorMessage: failedSendErrorMessage }], estimatedBatches: [], batches: [] }],
+      isEstimating: false,
+      isSending: false,
+      containsEstimatingError: false,
+      containsSendingError: false,
     }));
 
     const user = userEvent.setup();

--- a/src/components/Form/AssetSelect/index.tsx
+++ b/src/components/Form/AssetSelect/index.tsx
@@ -14,7 +14,7 @@ import Select, { SelectOption } from '../Select';
 
 // utils
 import { formatAmountDisplay } from '../../../utils/number';
-import { nativeAssetPerChainId } from '../../../utils/blockchain';
+import { getNativeAssetForChainId } from '../../../utils/blockchain';
 
 export interface AssetSelectOption extends SelectOption {
   asset: TokenListToken;
@@ -43,7 +43,7 @@ const AssetSelect = ({ defaultSelectedId, onChange }: {
       if (expired) return;
 
       // add native asset
-      const nativeAsset = nativeAssetPerChainId[chainId];
+      const nativeAsset = getNativeAssetForChainId(chainId);
       if (nativeAsset) {
         assets = [
           nativeAsset,

--- a/src/containers/Main.tsx
+++ b/src/containers/Main.tsx
@@ -4,7 +4,7 @@ import { PrivyProvider, usePrivy, useWallets } from '@privy-io/react-auth';
 import { useEffect, useState } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
-import { goerli, mainnet } from 'viem/chains';
+import { mainnet, sepolia } from 'viem/chains';
 
 // components
 import BottomMenu from '../components/BottomMenu';
@@ -90,7 +90,7 @@ const Main = () => {
           appId={process.env.REACT_APP_PRIVY_APP_ID as string}
           config={{
             appearance: { theme: 'dark' },
-            defaultChain: process.env.REACT_APP_USE_TESTNETS === 'true' ? goerli : mainnet,
+            defaultChain: process.env.REACT_APP_USE_TESTNETS === 'true' ? sepolia : mainnet,
             embeddedWallets: {
               createOnLogin: 'users-without-wallets'
             }

--- a/src/containers/Main.tsx
+++ b/src/containers/Main.tsx
@@ -4,6 +4,7 @@ import { PrivyProvider, usePrivy, useWallets } from '@privy-io/react-auth';
 import { useEffect, useState } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
+import { goerli, mainnet } from 'viem/chains';
 
 // components
 import BottomMenu from '../components/BottomMenu';
@@ -39,7 +40,8 @@ const AppAuthController = () => {
       // @ts-expect-error: provider type mismatch
       // TODO: fix provider types by either updating @etherspot/prime-sdk or @etherspot/transaction-kit
       setProvider(privyEthereumProvider.walletProvider);
-      setChainId(+wallets[0].chainId.split(':')[1]); // extract from CAIP-2
+      const walletChainId = +wallets[0].chainId.split(':')[1]; // extract from CAIP-2
+      setChainId(walletChainId);
     }
 
     updateProvider();
@@ -51,7 +53,11 @@ const AppAuthController = () => {
 
   if (authenticated && provider && chainId) {
     return (
-      <EtherspotTransactionKit provider={provider} chainId={chainId}>
+      <EtherspotTransactionKit
+        provider={provider}
+        chainId={chainId}
+        projectKey={process.env.REACT_APP_ETHERSPOT_PROJECT_KEY || undefined}
+      >
         <BrowserRouter>
           <BottomMenuModalProvider>
             <AuthContentWrapper>
@@ -84,6 +90,7 @@ const Main = () => {
           appId={process.env.REACT_APP_PRIVY_APP_ID as string}
           config={{
             appearance: { theme: 'dark' },
+            defaultChain: process.env.REACT_APP_USE_TESTNETS === 'true' ? goerli : mainnet,
             embeddedWallets: {
               createOnLogin: 'users-without-wallets'
             }

--- a/src/test-utils/setupJest.ts
+++ b/src/test-utils/setupJest.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TextEncoder, TextDecoder } from 'util';
 
 // jest-dom adds custom jest matchers for asserting on DOM nodes.
 // allows you to do things like:
@@ -8,13 +9,17 @@ import '@testing-library/jest-dom';
 import 'jest-styled-components';
 import * as TransactionKit from '@etherspot/transaction-kit';
 
+// polyfill for TextEncoder and TextDecoder for jsdom environment (viem dep related)
+Object.assign(global, { TextDecoder, TextEncoder });
+
 jest.mock('@firebase/app');
 jest.mock('@firebase/analytics');
 
 jest.mock('@privy-io/react-auth', () => ({
   PrivyProvider: ({ children }: { children: React.ReactNode }) => children,
   usePrivy: jest.fn(() => ({ authenticated: false })),
-  useWallets: jest.fn(() => ({}))
+  useWallets: jest.fn(() => ({})),
+  useLogout: jest.fn(() => ({ logout: jest.fn() })),
 }));
 
 export const etherspotTestAssets = [
@@ -34,6 +39,10 @@ jest.spyOn(TransactionKit, 'useEtherspotTransactions').mockReturnValue(({
   batches: [],
   estimate: async () => [],
   send: async () => [{ sentBatches: [{ userOpHash: '0x123' }], estimatedBatches: [], batches: [] }],
+  isEstimating: false,
+  isSending: false,
+  containsEstimatingError: false,
+  containsSendingError: false,
 }));
 
 jest.spyOn(TransactionKit, 'useEtherspotBalances').mockReturnValue(({

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -17,7 +17,8 @@
   "action": {
     "getStarted": "Get Started",
     "next": "Next",
-    "send": "Send"
+    "send": "Send",
+    "logout": "Logout"
   },
   "error": {
     "pageNotFound": "Page not found",

--- a/src/utils/blockchain.tsx
+++ b/src/utils/blockchain.tsx
@@ -1,5 +1,12 @@
 import { ethers } from 'ethers';
 import { TokenListToken } from '@etherspot/prime-sdk';
+import {
+  polygon,
+  gnosis,
+  avalanche,
+  bsc,
+  polygonMumbai,
+} from 'viem/chains';
 
 export const isValidEthereumAddress = (address: string | undefined): boolean => {
   if (!address) return false;
@@ -14,35 +21,10 @@ export const isValidEthereumAddress = (address: string | undefined): boolean => 
 };
 
 /**
- * Cross-check with:
- * - https://etherspot.fyi/prime-sdk/chains-supported#testnets
- * - https://docs.privy.io/guide/configuration/networks#default-configuration
- */
-export const MAINNET_CHAIN_ID = {
-  ETHEREUM_MAINNET: 1,
-  POLYGON: 137,
-  OPTIMISM: 10,
-  ARBITRUM: 42161,
-  GNOSIS: 100,
-  BASE: 8453,
-  AVALANCHE: 43114,
-  BINANCE: 56,
-  LINEA: 59144,
-};
-
-/**
- * Cross-check with:
+ * Cross-check for supported with:
  * - https://etherspot.fyi/prime-sdk/chains-supported
  * - https://docs.privy.io/guide/configuration/networks#default-configuration
  */
-export const TESTNET_CHAIN_ID = {
-  POLYGON_MUMBAI: 80001,
-  SEPOLIA: 11155111,
-  GOERLI: 5,
-  BASE_GOERLI: 84531,
-  ARBITRUM_GOERLI: 421613,
-};
-
 export const getNativeAssetForChainId = (chainId: number): TokenListToken => {
   // return different native asset for chains where it's not Ether (ETH), otherwise return Ether (ETH)
   const nativeAsset = {
@@ -54,35 +36,33 @@ export const getNativeAssetForChainId = (chainId: number): TokenListToken => {
     logoURI: 'https://public.etherspot.io/buidler/chain_logos/ethereum.png',
   };
 
-  if (chainId === MAINNET_CHAIN_ID.POLYGON
-    || chainId === TESTNET_CHAIN_ID.POLYGON_MUMBAI) {
+  // only mumbai testnet is supported on Prime SDK
+  if (chainId === polygon.id
+    || chainId === polygonMumbai.id) {
     nativeAsset.name = 'Matic';
     nativeAsset.symbol = 'MATIC';
     nativeAsset.logoURI = 'https://public.etherspot.io/buidler/chain_logos/native_tokens/matic.png';
   }
 
-  if (chainId === MAINNET_CHAIN_ID.GNOSIS) {
+  // gnosis testnet not supported on Prime SDK
+  if (chainId === gnosis.id) {
     nativeAsset.name = 'XDAI';
     nativeAsset.symbol = 'XDAI';
     nativeAsset.logoURI = 'https://public.etherspot.io/buidler/chain_logos/native_tokens/xdai.png';
   }
 
-  if (chainId === MAINNET_CHAIN_ID.AVALANCHE) {
+  // avalanche testnet not supported on Prime SDK
+  if (chainId === avalanche.id) {
     nativeAsset.name = 'AVAX';
     nativeAsset.symbol = 'AVAX';
     nativeAsset.logoURI = 'https://public.etherspot.io/buidler/chain_logos/avalanche.svg';
   }
 
-  if (chainId === MAINNET_CHAIN_ID.BINANCE) {
+  // bsc testnet not supported on Prime SDK
+  if (chainId === bsc.id) {
     nativeAsset.name = 'BNB';
     nativeAsset.symbol = 'BNB';
     nativeAsset.logoURI = 'https://public.etherspot.io/buidler/chain_logos/native_tokens/bnb.png';
-  }
-
-  if (chainId === MAINNET_CHAIN_ID.ARBITRUM) {
-    nativeAsset.name = 'BNB';
-    nativeAsset.symbol = 'BNB';
-    nativeAsset.logoURI = 'https://public.etherspot.io/buidler/chain_logos/binance.svg';
   }
 
   return nativeAsset;

--- a/src/utils/blockchain.tsx
+++ b/src/utils/blockchain.tsx
@@ -13,63 +13,77 @@ export const isValidEthereumAddress = (address: string | undefined): boolean => 
   return false;
 };
 
+/**
+ * Cross-check with:
+ * - https://etherspot.fyi/prime-sdk/chains-supported#testnets
+ * - https://docs.privy.io/guide/configuration/networks#default-configuration
+ */
 export const MAINNET_CHAIN_ID = {
   ETHEREUM_MAINNET: 1,
   POLYGON: 137,
-  BINANCE: 56,
-  XDAI: 100,
-  AVALANCHE: 43114,
   OPTIMISM: 10,
   ARBITRUM: 42161,
+  GNOSIS: 100,
+  BASE: 8453,
+  AVALANCHE: 43114,
+  BINANCE: 56,
+  LINEA: 59144,
 };
 
-export const nativeAssetPerChainId: { [chainId: number]: TokenListToken | undefined } = {
-  [MAINNET_CHAIN_ID.ETHEREUM_MAINNET]: {
-    chainId: MAINNET_CHAIN_ID.ETHEREUM_MAINNET,
+/**
+ * Cross-check with:
+ * - https://etherspot.fyi/prime-sdk/chains-supported
+ * - https://docs.privy.io/guide/configuration/networks#default-configuration
+ */
+export const TESTNET_CHAIN_ID = {
+  POLYGON_MUMBAI: 80001,
+  SEPOLIA: 11155111,
+  GOERLI: 5,
+  BASE_GOERLI: 84531,
+  ARBITRUM_GOERLI: 421613,
+};
+
+export const getNativeAssetForChainId = (chainId: number): TokenListToken => {
+  // return different native asset for chains where it's not Ether (ETH), otherwise return Ether (ETH)
+  const nativeAsset = {
+    chainId,
     address: ethers.constants.AddressZero,
     name: 'Ether',
     symbol: 'ETH',
     decimals: 18,
     logoURI: 'https://public.etherspot.io/buidler/chain_logos/ethereum.png',
-  },
-  [MAINNET_CHAIN_ID.POLYGON]: {
-    chainId: MAINNET_CHAIN_ID.POLYGON,
-    address: ethers.constants.AddressZero,
-    name: 'Matic',
-    symbol: 'MATIC',
-    decimals: 18,
-    logoURI: 'https://public.etherspot.io/buidler/chain_logos/native_tokens/matic.png',
-  },
-  [MAINNET_CHAIN_ID.XDAI]: {
-    chainId: MAINNET_CHAIN_ID.XDAI,
-    address: ethers.constants.AddressZero,
-    name: 'xDAI',
-    symbol: 'XDAI',
-    decimals: 18,
-    logoURI: 'https://public.etherspot.io/buidler/chain_logos/native_tokens/xdai.png',
-  },
-  [MAINNET_CHAIN_ID.AVALANCHE]: {
-    chainId: MAINNET_CHAIN_ID.AVALANCHE,
-    address: ethers.constants.AddressZero,
-    name: 'Avalanche',
-    symbol: 'AVAX',
-    decimals: 18,
-    logoURI: 'https://public.etherspot.io/buidler/chain_logos/avalanche.svg',
-  },
-  [MAINNET_CHAIN_ID.OPTIMISM]: {
-    chainId: MAINNET_CHAIN_ID.OPTIMISM,
-    address: ethers.constants.AddressZero,
-    name: 'Optimism',
-    symbol: 'ETH',
-    decimals: 18,
-    logoURI: 'https://public.etherspot.io/buidler/chain_logos/ethereum.png',
-  },
-  [MAINNET_CHAIN_ID.ARBITRUM]: {
-    chainId: MAINNET_CHAIN_ID.ARBITRUM,
-    address: ethers.constants.AddressZero,
-    name: 'Arbitrum',
-    symbol: 'ETH',
-    decimals: 18,
-    logoURI: 'https://public.etherspot.io/buidler/chain_logos/ethereum.png',
-  },
-};
+  };
+
+  if (chainId === MAINNET_CHAIN_ID.POLYGON
+    || chainId === TESTNET_CHAIN_ID.POLYGON_MUMBAI) {
+    nativeAsset.name = 'Matic';
+    nativeAsset.symbol = 'MATIC';
+    nativeAsset.logoURI = 'https://public.etherspot.io/buidler/chain_logos/native_tokens/matic.png';
+  }
+
+  if (chainId === MAINNET_CHAIN_ID.GNOSIS) {
+    nativeAsset.name = 'XDAI';
+    nativeAsset.symbol = 'XDAI';
+    nativeAsset.logoURI = 'https://public.etherspot.io/buidler/chain_logos/native_tokens/xdai.png';
+  }
+
+  if (chainId === MAINNET_CHAIN_ID.AVALANCHE) {
+    nativeAsset.name = 'AVAX';
+    nativeAsset.symbol = 'AVAX';
+    nativeAsset.logoURI = 'https://public.etherspot.io/buidler/chain_logos/avalanche.svg';
+  }
+
+  if (chainId === MAINNET_CHAIN_ID.BINANCE) {
+    nativeAsset.name = 'BNB';
+    nativeAsset.symbol = 'BNB';
+    nativeAsset.logoURI = 'https://public.etherspot.io/buidler/chain_logos/native_tokens/bnb.png';
+  }
+
+  if (chainId === MAINNET_CHAIN_ID.ARBITRUM) {
+    nativeAsset.name = 'BNB';
+    nativeAsset.symbol = 'BNB';
+    nativeAsset.logoURI = 'https://public.etherspot.io/buidler/chain_logos/binance.svg';
+  }
+
+  return nativeAsset;
+}

--- a/src/utils/blockchain.tsx
+++ b/src/utils/blockchain.tsx
@@ -62,7 +62,7 @@ export const getNativeAssetForChainId = (chainId: number): TokenListToken => {
   if (chainId === bsc.id) {
     nativeAsset.name = 'BNB';
     nativeAsset.symbol = 'BNB';
-    nativeAsset.logoURI = 'https://public.etherspot.io/buidler/chain_logos/native_tokens/bnb.png';
+    nativeAsset.logoURI = 'https://public.etherspot.io/buidler/chain_logos/binance.svg';
   }
 
   return nativeAsset;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Updated `@privy-io/react-auth` to `1.54.3`
- Updated `@etherspot/transaction-kit` to `0.7.0`
- Added `viem` utils for Privy supported `Chain` type
- Fixed mainnet and testnet native chain assets
- Added `@etherspot/transaction-kit` Etherspot `projectKey` support
- Added `REACT_APP_USE_TESTNETS` env var to enable testnets by default (default testnet chain – Goerli)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally sent 0.001 ETH on Goerli and ran JS tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
