### PR TITLE
fixed privy social login provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "pillarx",
-  "version": "0.2.10",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pillarx",
-      "version": "0.2.10",
+      "version": "0.2.1",
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
         "@etherspot/transaction-kit": "^0.7.0",
         "@mui/joy": "^5.0.0-beta.22",
-        "@privy-io/react-auth": "^1.54.3",
+        "@privy-io/react-auth": "^1.55.0",
         "@react-spring/web": "^9.7.3",
         "@sentry/cli": "^2.21.5",
         "@sentry/react": "^7.81.1",
@@ -6440,9 +6440,9 @@
       }
     },
     "node_modules/@privy-io/react-auth": {
-      "version": "1.54.3",
-      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-1.54.3.tgz",
-      "integrity": "sha512-Wxp+RRvGaG6U2FSPTyxji95l8DU+7FY38JCLGC6BSzmnD0xwDR2QFxpQdt9pftYyhd/UcCY89MU9DiGWPc+mUQ==",
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-1.55.1.tgz",
+      "integrity": "sha512-uIUS0d6K61N3OtsT4MSqRJ6bZ+M4j27zc74ftkv3X8XLMkq90YypDuzj44dMBzoDX0Z96DGTQEE6Yh/Hmw5HOQ==",
       "dependencies": {
         "@coinbase/wallet-sdk": "^3.9.0",
         "@ethersproject/abstract-signer": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pillarx",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "start": "react-scripts start",
@@ -14,7 +14,7 @@
     "@emotion/styled": "^11.11.0",
     "@etherspot/transaction-kit": "^0.7.0",
     "@mui/joy": "^5.0.0-beta.22",
-    "@privy-io/react-auth": "^1.54.3",
+    "@privy-io/react-auth": "^1.55.0",
     "@react-spring/web": "^9.7.3",
     "@sentry/cli": "^2.21.5",
     "@sentry/react": "^7.81.1",

--- a/src/containers/Main.tsx
+++ b/src/containers/Main.tsx
@@ -1,4 +1,4 @@
-import { WalletProviderLike } from '@etherspot/prime-sdk';
+import { WalletProviderLike, Web3eip1193WalletProvider } from '@etherspot/prime-sdk';
 import { EtherspotTransactionKit } from '@etherspot/transaction-kit';
 import { PrivyProvider, usePrivy, useWallets } from '@privy-io/react-auth';
 import { useEffect, useState } from 'react';
@@ -34,12 +34,16 @@ const AppAuthController = () => {
     const updateProvider = async () => {
       if (!wallets.length) return; // not yet ready
 
-      const privyEthereumProvider = await wallets[0].getEthereumProvider();
-      if (expired) return;
+      const privyEthereumProvider = await wallets[0].getWeb3jsProvider();
 
       // @ts-expect-error: provider type mismatch
       // TODO: fix provider types by either updating @etherspot/prime-sdk or @etherspot/transaction-kit
-      setProvider(privyEthereumProvider.walletProvider);
+      const newProvider = new Web3eip1193WalletProvider(privyEthereumProvider.walletProvider);
+      await newProvider.refresh();
+
+      if (expired) return;
+
+      setProvider(newProvider);
       const walletChainId = +wallets[0].chainId.split(':')[1]; // extract from CAIP-2
       setChainId(walletChainId);
     }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Fixes issue where rpc provider is missing when connected with Privy social connector.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally with Google login and metamask.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
