### PR TITLE
fix/PRO-2560/big-screen-scrolling-max-width

### DIFF
--- a/src/apps/pillarx-app/index.tsx
+++ b/src/apps/pillarx-app/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { createRef, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import './styles/tailwindPillarX.css';
@@ -10,6 +10,7 @@ import { Projection } from '../../types/api';
 import { useWalletAddress } from '@etherspot/transaction-kit';
 import { useGetTilesInfoQuery } from './api/homeFeed';
 import { useGetWaitlistQuery } from '../../services/pillarXApiWaitlist';
+import useRefDimensions from './hooks/useRefDimensions';
 
 // utils
 import { componentMap } from './utils/configComponent';
@@ -29,9 +30,12 @@ import { PAGE_LIMIT } from './utils/constants';
 const App = () => {
   const [t] = useTranslation();
   const [page, setPage] = useState(1);
-  const [isLoadingNextPage, setIsLoadingNextPage] = useState(true);
+  const [isLoadingNextPage, setIsLoadingNextPage] = useState(false);
   const [pageData, setPageData] = useState<Projection[]>([]);
   const walletAddress = useWalletAddress();
+
+  const divRef = createRef<HTMLDivElement>();
+  const dimensions = useRefDimensions(divRef);
 
   // The API call will not fire if there is no walletAddress
   const { data: apiData, isLoading: isApiLoading, isFetching, isSuccess } = useGetTilesInfoQuery( { page: page, address: walletAddress || '' }, { skip: !walletAddress });
@@ -56,26 +60,23 @@ const App = () => {
 
   // scroll handler makes sure that when reaching the end of the page, it loads the next page
   useEffect(() => {
-    const handleScroll = () => {
-      const { scrollTop, clientHeight, scrollHeight } =
-        document.documentElement;
-      if ((scrollTop + clientHeight >= scrollHeight - 300) && !isFetching && isLoadingNextPage) {
-        if (PAGE_LIMIT === 0) {
+    const handleScrollOrWheel = () => {
+      const { scrollTop, clientHeight, scrollHeight } = document.documentElement;
+      if ((scrollTop + clientHeight >= scrollHeight - 300 || dimensions.height <= window.innerHeight) && !isFetching && isLoadingNextPage) {
+        if (PAGE_LIMIT === 0 || page < PAGE_LIMIT) {
           setIsLoadingNextPage(false);
-          setPage((prevPage) => prevPage + 1);
-        }
-        if (page < PAGE_LIMIT) {
-          setIsLoadingNextPage(false);
-          setPage((prevPage) => prevPage + 1);
+          setPage(() => page + 1);
         }
       }
     };
 
-    window.addEventListener('scroll', handleScroll);
+    window.addEventListener('scroll', handleScrollOrWheel);
+    window.addEventListener('wheel', handleScrollOrWheel);
     return () => {
-      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('scroll', handleScrollOrWheel);
+      window.removeEventListener('wheel', handleScrollOrWheel);
     };
-  }, [isFetching, isLoadingNextPage, page]);
+  }, [dimensions.height, isFetching, isLoadingNextPage, page]);
 
   // useMemo here to reload all components and create a smoother scrolling experience
   const DisplayAllTiles = useMemo(() => {
@@ -98,7 +99,7 @@ const App = () => {
     <Wrapper>
       <PillarXLogo src={pillarLogoLight} className='object-contain h-[20px] mb-[70px] mobile:h-[18px] mobile:mb-[58px] self-center' />
       <H1 className='desktop:py-2.5 desktop:px-4 tablet:py-2.5 tablet:px-4 mobile:px-0'>{t`content.welcomeBackTester`} {waitlistData?.number && !isWaitlistLoading && isWaitlistSucess ? waitlistData.number : '...'}</H1>
-      <div className='flex flex-col gap-[40px] tablet:gap-[28px] mobile:gap-[32px]'>
+      <div ref={divRef} className='flex flex-col gap-[40px] tablet:gap-[28px] mobile:gap-[32px]'>
         {DisplayAllTiles}
         {isFetching && <><SkeletonTiles type='horizontal' /><SkeletonTiles type='vertical' /></>}
         {page >= PAGE_LIMIT && <Body className='text-center mb-12'>That&apos;s all for now</Body>}
@@ -112,6 +113,7 @@ const Wrapper = styled.div`
   width: 100%;
   margin: 0 auto;
   flex-direction: column;
+  max-width: 1248px;
 
   @media (min-width: 800px) {
     padding: 50px 60px


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- If the user is using a big screen, it can now have access to the infinite scrolling feature of the app.
- The max width of the page and tiles is set up to 1248px
- The page-1 of the api data is always showing first, better management of pagination and infinite scrolling together

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Existing unit tests, manual testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
