### PR TITLE
feature/PRO-3037/auto-token-download

### DIFF
--- a/.github/workflows/download-latest-tokenlist.yml
+++ b/.github/workflows/download-latest-tokenlist.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
       - name: Fetch latest token list
         run: |
           curl -H "Accept: application/json" -X GET "https://production-api.mobula.io/api/1/all?fields=id,decimals,logo,contracts,blockchains" --create-dirs -o src/data/tokens.json

--- a/.github/workflows/download-latest-tokenlist.yml
+++ b/.github/workflows/download-latest-tokenlist.yml
@@ -1,7 +1,10 @@
 name: Download latest token list
 run-name: ${{ github.actor }} opened a pull request! Downloading the latest token list...
 
-on: [pull_request]
+on:
+  pull_request:
+    branches-ignore:
+      - 'main'
 
 jobs:
   download-tokenlist:

--- a/.github/workflows/download-latest-tokenlist.yml
+++ b/.github/workflows/download-latest-tokenlist.yml
@@ -1,0 +1,22 @@
+name: Download latest token list
+run-name: ${{ github.actor }} opened a pull request! Downloading the latest token list...
+
+on: [pull_request]
+
+jobs:
+  download-tokenlist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Fetch latest token list
+        run: |
+          curl -H "Accept: application/json" -X GET "https://production-api.mobula.io/api/1/all?fields=id,decimals,logo,contracts,blockchains" -o src/data/tokens.json
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          author_name: KioBot
+          author_email: kieran@pillarproject.io
+          message: 'KioBot downloaded the latest token list and updated tokens.json'
+          add: 'src/data/tokens.json'
+        

--- a/.github/workflows/download-latest-tokenlist.yml
+++ b/.github/workflows/download-latest-tokenlist.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Fetch latest token list
         run: |
-          curl -H "Accept: application/json" -X GET "https://production-api.mobula.io/api/1/all?fields=id,decimals,logo,contracts,blockchains" -o src/data/tokens.json
+          curl -H "Accept: application/json" -X GET "https://production-api.mobula.io/api/1/all?fields=id,decimals,logo,contracts,blockchains" --create-dirs -o src/data/tokens.json
       - name: Commit changes
         uses: EndBug/add-and-commit@v9
         with:

--- a/.github/workflows/download-latest-tokenlist.yml
+++ b/.github/workflows/download-latest-tokenlist.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   download-tokenlist:
+    if: github.run_number == 1
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/download-latest-tokenlist.yml
+++ b/.github/workflows/download-latest-tokenlist.yml
@@ -25,4 +25,3 @@ jobs:
           author_email: kieran@pillarproject.io
           message: 'KioBot downloaded the latest token list and updated tokens.json'
           add: 'src/data/tokens.json'
-        


### PR DESCRIPTION
## Description
- Adds a new GitHub Action to automatically download, commit and push an updated token list from Mobula to the branch repository. Ignores any PR going to `main` as at this point the token data list should already have been updated.

## How Has This Been Tested?
- On GitHub via this PR

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced an automated workflow that updates the token list when pull requests are opened, ensuring that token information remains current with minimal manual intervention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->