### PR TITLE
fix of scientific number for token price

### DIFF
--- a/src/apps/pillarx-app/components/MediaGridCollection/tests/__snapshots__/DisplayCollectionImage.test.tsx.snap
+++ b/src/apps/pillarx-app/components/MediaGridCollection/tests/__snapshots__/DisplayCollectionImage.test.tsx.snap
@@ -23,65 +23,69 @@ exports[`<DisplayCollectionImage /> renders correctly and matches snapshot witho
     data-testid="random-avatar"
     fill="none"
     role="img"
-    viewBox="0 0 90 90"
+    viewBox="0 0 80 80"
     xmlns="http://www.w3.org/2000/svg"
   >
     <mask
-      height={90}
+      height={80}
       id=":r0:"
       maskUnits="userSpaceOnUse"
-      width={90}
+      width={80}
       x={0}
       y={0}
     >
       <rect
         fill="#FFFFFF"
-        height={90}
-        width={90}
+        height={80}
+        width={80}
       />
     </mask>
     <g
       mask="url(#:r0:)"
     >
       <path
-        d="M0 0h90v45H0z"
-        fill="#F0AB3D"
+        d="M0 0h80v40H0z"
+        fill="url(#gradient_paint0_linear_image-name)"
       />
       <path
-        d="M0 45h90v45H0z"
-        fill="#C271B4"
-      />
-      <path
-        d="M83 45a38 38 0 00-76 0h76z"
-        fill="#C271B4"
-      />
-      <path
-        d="M83 45a38 38 0 01-76 0h76z"
-        fill="#C20D90"
-      />
-      <path
-        d="M77 45a32 32 0 10-64 0h64z"
-        fill="#C20D90"
-      />
-      <path
-        d="M77 45a32 32 0 11-64 0h64z"
-        fill="#92A1C6"
-      />
-      <path
-        d="M71 45a26 26 0 00-52 0h52z"
-        fill="#92A1C6"
-      />
-      <path
-        d="M71 45a26 26 0 01-52 0h52z"
-        fill="#F0AB3D"
-      />
-      <circle
-        cx={45}
-        cy={45}
-        fill="#146A7C"
-        r={23}
+        d="M0 40h80v40H0z"
+        fill="url(#gradient_paint1_linear_image-name)"
       />
     </g>
+    <defs>
+      <linearGradient
+        gradientUnits="userSpaceOnUse"
+        id="gradient_paint0_linear_image-name"
+        x1={40}
+        x2={40}
+        y1={0}
+        y2={40}
+      >
+        <stop
+          stopColor="#F0AB3D"
+        />
+        <stop
+          offset={1}
+          stopColor="#C271B4"
+        />
+      </linearGradient>
+      <linearGradient
+        gradientUnits="userSpaceOnUse"
+        id="gradient_paint1_linear_image-name"
+        x1={40}
+        x2={40}
+        y1={40}
+        y2={80}
+      >
+        <stop
+          stopColor="#C20D90"
+        />
+        <stop
+          offset={1}
+          stopColor="#92A1C6"
+        />
+      </linearGradient>
+    </defs>
   </svg>
 </div>
 `;

--- a/src/apps/pillarx-app/components/PointsTile/test/__snapshots__/PointsTile.test.tsx.snap
+++ b/src/apps/pillarx-app/components/PointsTile/test/__snapshots__/PointsTile.test.tsx.snap
@@ -166,14 +166,14 @@ exports[`<PointsTile /> renders correctly and matches snapshot 1`] = `
                           d
                         </span>
                          
-                        -11
+                        -13
                         <span
                           class="text-base"
                         >
                           h
                         </span>
                          
-                        -30
+                        -10
                         <span
                           class="text-base"
                         >
@@ -432,14 +432,14 @@ exports[`<PointsTile /> renders correctly and matches snapshot 1`] = `
                         d
                       </span>
                        
-                      -11
+                      -13
                       <span
                         class="text-base"
                       >
                         h
                       </span>
                        
-                      -30
+                      -10
                       <span
                         class="text-base"
                       >

--- a/src/apps/token-atlas/components/TokenInfoColumn/test/__snapshots__/TokenInfoColumn.test.tsx.snap
+++ b/src/apps/token-atlas/components/TokenInfoColumn/test/__snapshots__/TokenInfoColumn.test.tsx.snap
@@ -369,7 +369,7 @@ exports[`<TokenInfoColumn /> renders correctly and matches snapshot 1`] = `
         <p
           className="text-[13px] font-semibold undefined"
         >
-          3.3999999
+          3.4
           %
         </p>
       </div>

--- a/src/apps/token-atlas/utils/converters.ts
+++ b/src/apps/token-atlas/utils/converters.ts
@@ -4,6 +4,14 @@ export const hasThreeZerosAfterDecimal = (num: number): boolean => {
 };
 
 export const limitDigits = (num: number): number => {
+  // Check if the number is in scientific notation
+  const isScientific = num.toExponential().includes('e');
+
+  if (isScientific) {
+    // Convert number to scientific notation with 2 decimal max
+    return parseFloat(num.toExponential(2));
+  }
+
   // Convert number to string with a max of 18 decimals
   const numStr = num.toFixed(18);
   const [integerPart, fractionalPart] = numStr.split('.');


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Fix token price on Token Atlas when it is a very small decimal number

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manual testing and existing unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced numeric formatting to better display numbers, including those expressed in scientific notation with a concise two-decimal format.
	- Maintained consistent formatting for standard numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->