### PR TITLE
send transaction batch speed improvement

### DIFF
--- a/src/components/BottomMenuModal/SendModal/SendModalBatchesTabView.tsx
+++ b/src/components/BottomMenuModal/SendModal/SendModalBatchesTabView.tsx
@@ -52,7 +52,7 @@ const SendModalBatchesTabView = () => {
   const [errorMessage, setErrorMessage] = React.useState<
     Record<number, string>
   >({});
-  const { send, estimate } = useEtherspotTransactions();
+  const { send } = useEtherspotTransactions();
   const { showHistory } = useBottomMenuModal();
   const contextNfts = useContext(AccountNftsContext);
   const contextBalances = useContext(AccountBalancesContext);
@@ -89,12 +89,12 @@ const SendModalBatchesTabView = () => {
     setEstimatedCostFormatted((prev) => ({ ...prev, [chainId]: '' }));
     setErrorMessage((prev) => ({ ...prev, [chainId]: '' }));
 
-    const estimated = await estimate([batchId]);
+    const sent = await send([batchId]);
 
-    const estimatedCostBN = estimated?.[0]?.estimatedBatches?.[0]?.cost;
+    const estimatedCostBN = sent?.[0]?.estimatedBatches?.[0]?.cost;
     if (estimatedCostBN) {
       const nativeAsset = getNativeAssetForChainId(
-        estimated[0].estimatedBatches[0].chainId as number
+        sent[0].estimatedBatches[0].chainId as number
       );
       const estimatedCost = ethers.utils.formatUnits(
         estimatedCostBN,
@@ -105,11 +105,11 @@ const SendModalBatchesTabView = () => {
         [chainId]: `${formatAmountDisplay(estimatedCost, 0, 6)} ${nativeAsset.symbol}`,
       }));
     } else {
-      console.warn('Unable to get estimated cost', estimated);
+      console.warn('Unable to get estimated cost', sent);
     }
 
     const estimationErrorMessage =
-      estimated?.[0]?.estimatedBatches?.[0]?.errorMessage;
+      sent?.[0]?.estimatedBatches?.[0]?.errorMessage;
     if (estimationErrorMessage) {
       setErrorMessage((prev) => ({
         ...prev,
@@ -118,8 +118,6 @@ const SendModalBatchesTabView = () => {
       setIsSending((prev) => ({ ...prev, [chainId]: false }));
       return;
     }
-
-    const sent = await send([batchId]);
 
     const sendingErrorMessage = sent?.[0]?.sentBatches?.[0]?.errorMessage;
     if (sendingErrorMessage) {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Removed double estimation for sending  transactions batches

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manual Testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the transaction sending process by removing an earlier cost estimation step.
	- Updated the messaging to provide direct feedback on transaction performance and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->