### PR TITLE
Smooth out the animated tile transitions in home feed

### DIFF
--- a/src/apps/pillarx-app/components/AnimatedTile/AnimatedTitle.tsx
+++ b/src/apps/pillarx-app/components/AnimatedTile/AnimatedTitle.tsx
@@ -32,8 +32,8 @@ const AnimatedTile = ({
   const tileDisplay = meta?.display;
 
   const [ref, inView] = useInView({
-    threshold: 0.1,
-    rootMargin: '100px 0px 0px 0px',
+    threshold: 0.2,
+    rootMargin: '75px 0px 0px 0px',
   });
 
   useEffect(() => {
@@ -53,7 +53,7 @@ const AnimatedTile = ({
 
   const animationProps = useSpring({
     transform:
-      inView && !isDataLoading ? 'translateY(0px)' : 'translateY(100px)',
+      inView && !isDataLoading ? 'translateY(0px)' : 'translateY(50px)',
     config: { tension: 170, friction: 26 },
     onRest: () => {
       if (inView) {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Smooth out the animation when tiles appears in the home feed to avoid any "jumping" effect

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manual Testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
