### PR TITLE
fix/PRO-3209/change-chainId-wallet-connect-privy

### DIFF
--- a/src/containers/Main.tsx
+++ b/src/containers/Main.tsx
@@ -15,7 +15,16 @@ import {
   WalletClient,
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { polygon, sepolia } from 'viem/chains';
+import {
+  arbitrum,
+  base,
+  bsc,
+  gnosis,
+  mainnet,
+  optimism,
+  polygon,
+  sepolia,
+} from 'viem/chains';
 
 // theme
 import { defaultTheme, GlobalStyle } from '../theme';
@@ -329,7 +338,17 @@ const Main = () => {
             appId={process.env.REACT_APP_PRIVY_APP_ID as string}
             config={{
               appearance: { theme: 'dark' },
-              defaultChain: isTestnet ? sepolia : polygon,
+              defaultChain: isTestnet ? sepolia : mainnet,
+              supportedChains: [
+                mainnet,
+                polygon,
+                gnosis,
+                arbitrum,
+                optimism,
+                base,
+                bsc,
+                sepolia,
+              ],
               embeddedWallets: {
                 createOnLogin: 'users-without-wallets',
               },


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Default chain id on privy provider changed to Mainnet
- Added all supported chains to the privy provider

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manual testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded support for additional blockchain networks, including mainnet, gnosis, arbitrum, optimism, base, and bsc.
  - Updated default and supported blockchain networks for improved connectivity options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->