### PR TITLE
fix receive modal closing and copy address

### DIFF
--- a/src/apps/pillarx-app/components/MediaGridCollection/tests/__snapshots__/DisplayCollectionImage.test.tsx.snap
+++ b/src/apps/pillarx-app/components/MediaGridCollection/tests/__snapshots__/DisplayCollectionImage.test.tsx.snap
@@ -23,64 +23,54 @@ exports[`<DisplayCollectionImage /> renders correctly and matches snapshot witho
     data-testid="random-avatar"
     fill="none"
     role="img"
-    viewBox="0 0 90 90"
+    viewBox="0 0 80 80"
     xmlns="http://www.w3.org/2000/svg"
   >
     <mask
-      height={90}
+      height={80}
       id=":r0:"
-      mask-type="alpha"
       maskUnits="userSpaceOnUse"
-      width={90}
+      width={80}
       x={0}
       y={0}
     >
       <rect
         fill="#FFFFFF"
-        height={90}
-        width={90}
+        height={80}
+        width={80}
       />
     </mask>
     <g
       mask="url(#:r0:)"
     >
-      <path
-        d="M0 0h90v45H0z"
+      <rect
         fill="#F0AB3D"
+        height={80}
+        width={80}
       />
-      <path
-        d="M0 45h90v45H0z"
+      <rect
         fill="#C271B4"
-      />
-      <path
-        d="M83 45a38 38 0 00-76 0h76z"
-        fill="#C271B4"
-      />
-      <path
-        d="M83 45a38 38 0 01-76 0h76z"
-        fill="#C20D90"
-      />
-      <path
-        d="M77 45a32 32 0 10-64 0h64z"
-        fill="#C20D90"
-      />
-      <path
-        d="M77 45a32 32 0 11-64 0h64z"
-        fill="#92A1C6"
-      />
-      <path
-        d="M71 45a26 26 0 00-52 0h52z"
-        fill="#92A1C6"
-      />
-      <path
-        d="M71 45a26 26 0 01-52 0h52z"
-        fill="#F0AB3D"
+        height={10}
+        transform="translate(6 -6) rotate(254 40 40)"
+        width={80}
+        x={10}
+        y={30}
       />
       <circle
-        cx={45}
-        cy={45}
-        fill="#146A7C"
-        r={23}
+        cx={40}
+        cy={40}
+        fill="#C20D90"
+        r={16}
+        transform="translate(-6 6)"
+      />
+      <line
+        stroke="#92A1C6"
+        strokeWidth={2}
+        transform="translate(-8 -8) rotate(148 40 40)"
+        x1={0}
+        x2={80}
+        y1={40}
+        y2={40}
       />
     </g>
   </svg>

--- a/src/apps/pillarx-app/components/ReceiveModal/ReceiveModal.tsx
+++ b/src/apps/pillarx-app/components/ReceiveModal/ReceiveModal.tsx
@@ -50,20 +50,6 @@ const ReceiveModal = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Click outside to close
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
-        handleOnCloseReceiveModal();
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   useEffect(() => {
     if (copied) {
       const timer = setTimeout(() => setCopied(false), 3000);
@@ -79,11 +65,14 @@ const ReceiveModal = () => {
     <div
       id="wallet-portfolio-tile-receive-modal"
       className="fixed inset-0 bg-[#12111680]/[.5] backdrop-blur-sm z-30"
+      onMouseDown={handleOnCloseReceiveModal}
+      data-testid="wallet-portfolio-tile-receive-modal"
     >
       <div className="fixed inset-0 flex items-center justify-center z-40 mobile:items-start tablet:items-start mt-20">
         <div
           ref={modalRef}
           className="relative flex flex-col w-full p-4 desktop:max-w-[446px] tablet:max-w-[446px] mobile:max-w-full mobile:mx-4 bg-container_grey border-[1px] border-white/[.05] rounded-2xl overflow-y-auto max-h-[75vh] mb-20"
+          onMouseDown={(e) => e.stopPropagation()} // Prevents closing when clicking inside
         >
           <div className="flex items-center justify-between mb-3">
             <p className="text-xl font-medium text-white">Receive</p>
@@ -100,39 +89,39 @@ const ReceiveModal = () => {
             withdraw them.
           </BodySmall>
           <Body className="text-white mb-3">EVM Address</Body>
-          <div className="flex items-center justify-between p-3 bg-lighter_container_grey rounded-[10px] mb-6 max-w-full">
-            <div className="flex-1 min-w-0">
-              <BodySmall className="text-white/[.5] font-normal truncate">
-                {!accountAddress
-                  ? 'We were not able to retrieve your EVM address, please check your internet connection and reload the page.'
-                  : accountAddress}
-              </BodySmall>
-            </div>
-            <div className="flex flex-shrink-0 pl-2">
-              {copied ? (
-                <MdCheck
-                  style={{
-                    width: '12px',
-                    height: '12px',
-                    color: 'white',
-                    opacity: 0.5,
-                  }}
-                />
-              ) : (
-                <CopyToClipboard
-                  text={accountAddress || ''}
-                  onCopy={() => setCopied(true)}
-                >
+          <CopyToClipboard
+            text={accountAddress || ''}
+            onCopy={() => setCopied(true)}
+          >
+            <div className="flex items-center justify-between p-3 bg-lighter_container_grey rounded-[10px] mb-6 max-w-full">
+              <div className="flex-1 min-w-0">
+                <BodySmall className="text-white/[.5] font-normal truncate">
+                  {!accountAddress
+                    ? 'We were not able to retrieve your EVM address, please check your internet connection and reload the page.'
+                    : accountAddress}
+                </BodySmall>
+              </div>
+              <div className="flex flex-shrink-0 pl-2">
+                {copied ? (
+                  <MdCheck
+                    style={{
+                      width: '12px',
+                      height: '12px',
+                      color: 'white',
+                      opacity: 0.5,
+                    }}
+                  />
+                ) : (
                   <img
                     src={CopyIcon}
                     alt="copy-evm-address"
                     className="w-3 h-3.5"
                     onClick={(e) => e.stopPropagation()}
                   />
-                </CopyToClipboard>
-              )}
+                )}
+              </div>
             </div>
-          </div>
+          </CopyToClipboard>
 
           <Body className="text-white mb-6">Supported Chains</Body>
           <div className="grid grid-cols-2 gap-4">

--- a/src/apps/pillarx-app/components/ReceiveModal/test/ReceiveModal.test.tsx
+++ b/src/apps/pillarx-app/components/ReceiveModal/test/ReceiveModal.test.tsx
@@ -146,8 +146,10 @@ describe('<ReceiveModal />', () => {
       'setIsReceiveModalOpen'
     );
 
-    render(<ReceiveModal />);
-    fireEvent.mouseDown(document); // simulates clicking outside modal
+    const { getByTestId } = render(<ReceiveModal />);
+
+    // Simulate mouse down oustide the modal
+    fireEvent.mouseDown(getByTestId('wallet-portfolio-tile-receive-modal'));
 
     expect(setIsReceiveModalOpenSpy).toHaveBeenCalledWith(false);
     expect(mockDispatch).toHaveBeenCalledWith({


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
-

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved modal closing behavior by handling outside clicks directly on the modal background, resulting in more localized and reliable event handling.
  - Simplified the copy-to-clipboard functionality for the address display, enhancing the user interface experience.

- **Tests**
  - Updated tests to accurately simulate clicking outside the modal for closing it, ensuring consistent behavior with the new implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->