### PR TITLE
fix/PRO-3382/undeployed-wallet-cost

### DIFF
--- a/src/apps/the-exchange/components/EnterAmount/EnterAmount.tsx
+++ b/src/apps/the-exchange/components/EnterAmount/EnterAmount.tsx
@@ -36,9 +36,19 @@ type EnterAmountProps = {
   type: CardPosition;
   tokenSymbol?: string;
   tokenBalance?: number;
+  tokenChain?: string;
+  isDeploymentCostLoading?: boolean;
+  deploymentCost?: number;
 };
 
-const EnterAmount = ({ type, tokenSymbol, tokenBalance }: EnterAmountProps) => {
+const EnterAmount = ({
+  type,
+  tokenSymbol,
+  tokenBalance,
+  tokenChain,
+  isDeploymentCostLoading,
+  deploymentCost,
+}: EnterAmountProps) => {
   const dispatch = useAppDispatch();
   const amountSwap = useAppSelector((state) => state.swap.amountSwap as number);
   const amountReceive = useAppSelector(
@@ -144,7 +154,7 @@ const EnterAmount = ({ type, tokenSymbol, tokenBalance }: EnterAmountProps) => {
 
     // Check if the value exceeds the max token amount limit
     if (tokenAmount > balance) {
-      return `The maximum amount of ${swapToken?.symbol} in your wallet is ${balance.toFixed(6)} ${swapToken?.symbol} - please change the amount and try again`;
+      return `The maximum amount of ${swapToken?.symbol}${deploymentCost && deploymentCost > 0 && ' spendable'} in your wallet is ${balance.toFixed(6)} ${swapToken?.symbol}${deploymentCost && deploymentCost > 0 && ` because your wallet is currently undeployed on ${tokenChain}`} - please change the amount and try again`;
     }
 
     return undefined;
@@ -199,14 +209,15 @@ const EnterAmount = ({ type, tokenSymbol, tokenBalance }: EnterAmountProps) => {
             className="text-black_grey font-normal !text-3xl outline-none focus:outline-none focus:ring-0 focus:bg-[#292D32]/[.05] focus:border-b focus:border-b-black_grey group-hover:bg-[#292D32]/[.05] group-hover:border-b group-hover:border-b-black_grey"
             data-testid="enter-amount-input"
           />
-          {tokenBalanceLimit(Number(inputValue), tokenBalance || 0) && (
-            <BodySmall
-              id="token-balance-limit-exchange"
-              data-testid="error-max-limit"
-            >
-              {tokenBalanceLimit(Number(inputValue), tokenBalance || 0)}
-            </BodySmall>
-          )}
+          {tokenBalanceLimit(Number(inputValue), tokenBalance || 0) &&
+            !isDeploymentCostLoading && (
+              <BodySmall
+                id="token-balance-limit-exchange"
+                data-testid="error-max-limit"
+              >
+                {tokenBalanceLimit(Number(inputValue), tokenBalance || 0)}
+              </BodySmall>
+            )}
         </>
       ) : (
         <ExchangeOffer

--- a/src/apps/the-exchange/components/SwapReceiveCard/SwapReceiveCard.tsx
+++ b/src/apps/the-exchange/components/SwapReceiveCard/SwapReceiveCard.tsx
@@ -1,19 +1,25 @@
 // services
-import { useEffect } from 'react';
+import { useWalletAddress } from '@etherspot/transaction-kit';
+import { useEffect, useMemo, useState } from 'react';
 
 // services
 import { useGetSearchTokensQuery } from '../../../../services/pillarXApiSearchTokens';
 import {
   Token,
   chainIdToChainNameTokensData,
+  chainNameDataCompatibility,
   chainNameToChainIdTokensData,
   convertAPIResponseToTokens,
 } from '../../../../services/tokensData';
+
+// utils
+import { isNativeToken } from '../../utils/wrappedTokens';
 
 // reducer
 import { setReceiveToken } from '../../reducer/theExchangeSlice';
 
 // hooks
+import useDeployWallet from '../../../../hooks/useDeployWallet';
 import { useAppDispatch, useAppSelector } from '../../hooks/useReducerHooks';
 
 // types
@@ -37,6 +43,8 @@ const SwapReceiveCard = ({
   onClick,
 }: SwapReceiveCardProps) => {
   const dispatch = useAppDispatch();
+  const accountAddress = useWalletAddress();
+  const { getWalletDeploymentCost } = useDeployWallet();
   const swapToken = useAppSelector((state) => state.swap.swapToken as Token);
   const receiveToken = useAppSelector(
     (state) => state.swap.receiveToken as Token
@@ -44,6 +52,8 @@ const SwapReceiveCard = ({
   const selectedToken = useAppSelector(
     (state) => state.tokenAtlas.selectedToken as SelectedTokenType | undefined
   );
+  const [deploymentCost, setDeploymentCost] = useState(0);
+  const [isDeploymentCostLoading, setIsDeploymentCostLoading] = useState(false);
 
   const isClickable =
     (position === CardPosition.SWAP && !swapToken) ||
@@ -108,6 +118,33 @@ const SwapReceiveCard = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [asset, searchData]);
 
+  useEffect(() => {
+    const getDeploymentCost = async () => {
+      if (!accountAddress || !swapToken?.blockchain) return;
+
+      setIsDeploymentCostLoading(true);
+      const cost = await getWalletDeploymentCost({
+        accountAddress,
+        chainId: chainNameToChainIdTokensData(swapToken.blockchain),
+      });
+      setDeploymentCost(cost);
+      setIsDeploymentCostLoading(false);
+    };
+
+    getDeploymentCost();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accountAddress, swapToken]);
+
+  const swapTokenBalance = useMemo(() => {
+    if (!swapToken || !swapToken.balance) return 0;
+
+    const adjustedBalance = isNativeToken(swapToken.contract)
+      ? swapToken.balance - deploymentCost
+      : swapToken.balance;
+
+    return adjustedBalance;
+  }, [swapToken, deploymentCost]);
+
   return (
     <div
       id="swap-receive-card-exchange"
@@ -144,8 +181,15 @@ const SwapReceiveCard = ({
             : receiveToken?.symbol
         }
         tokenBalance={
-          position === CardPosition.SWAP ? swapToken?.balance : undefined
+          position === CardPosition.SWAP ? swapTokenBalance : undefined
         }
+        tokenChain={
+          position === CardPosition.SWAP
+            ? chainNameDataCompatibility(swapToken?.blockchain)
+            : undefined
+        }
+        isDeploymentCostLoading={isDeploymentCostLoading}
+        deploymentCost={deploymentCost}
       />
     </div>
   );

--- a/src/hooks/useDeployWallet.tsx
+++ b/src/hooks/useDeployWallet.tsx
@@ -1,0 +1,227 @@
+import axios from 'axios';
+import { formatEther } from 'viem';
+
+const useDeployWallet = () => {
+  // This is to easily get the right localStorage key to retrieve
+  const getWalletDeployedLocalStorageKey = (
+    accountAddress: string,
+    chainId: number
+  ) => {
+    return `wallet_deployed_${accountAddress}_${chainId}`;
+  };
+
+  // This is to easily get the right localStorage status with the right localStorage key to retrieve
+  const getWalletDeployedLocalStorageStatus = (
+    accountAddress: string,
+    chainId: number
+  ): boolean | undefined => {
+    try {
+      const localStorageKey = getWalletDeployedLocalStorageKey(
+        accountAddress,
+        chainId
+      );
+      const localStorageValue = localStorage.getItem(localStorageKey);
+      if (localStorageValue === 'true') return true;
+      if (localStorageValue === 'false') return false;
+      return undefined; // Means it has not been added to localStorage yet
+    } catch (error) {
+      console.warn('Failed to read from localStorage:', error);
+      return undefined;
+    }
+  };
+
+  // This is to set the localStorage status with the right localStorage key
+  const setWalletDeployedLocalStorageStatus = (
+    accountAddress: string,
+    chainId: number,
+    isDeployed: boolean
+  ) => {
+    try {
+      const localStorageKey = getWalletDeployedLocalStorageKey(
+        accountAddress,
+        chainId
+      );
+      localStorage.setItem(localStorageKey, isDeployed.toString());
+    } catch (error) {
+      console.warn('Failed to write to localStorage:', error);
+    }
+  };
+
+  const getGasPrice = async (chainId: number): Promise<string | undefined> => {
+    const apiKey = process.env.REACT_APP_ETHERSPOT_DATA_API_KEY;
+
+    if (!chainId) {
+      console.error('getGasPrice: chainId is required');
+      return undefined;
+    }
+
+    if (!apiKey) {
+      console.error('getGasPrice: API key is missing');
+      return undefined;
+    }
+
+    const url = `https://rpc.etherspot.io/v2/${chainId}?api-key=${apiKey}`;
+
+    try {
+      const response = await axios.post(
+        url,
+        {
+          method: 'skandha_getGasPrice',
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+
+      return response.data.result.maxFeePerGas;
+    } catch (error) {
+      console.error('getGasPrice: Failed to get gas price', error);
+      return undefined;
+    }
+  };
+
+  const isWalletDeployed = async (
+    accountAddress: string,
+    chainId: number
+  ): Promise<boolean | undefined> => {
+    const apiKey = process.env.REACT_APP_ETHERSPOT_DATA_API_KEY;
+
+    if (!accountAddress) {
+      console.error('isWalletDeployed: accountAddress is required');
+      return undefined;
+    }
+
+    if (!chainId) {
+      console.error('isWalletDeployed: chainId is required');
+      return undefined;
+    }
+
+    if (!apiKey) {
+      console.error('isWalletDeployed: API key is missing');
+      return undefined;
+    }
+
+    // Checking if this wallet has been deployed before using localStorage
+    const localStorageStatus = getWalletDeployedLocalStorageStatus(
+      accountAddress,
+      chainId
+    );
+
+    // If wallet has been deployed no further calls will be made
+    if (localStorageStatus === true) {
+      return true;
+    }
+
+    // If wallet has not deployed, then we will check on chain
+    const url = `https://rpc.etherspot.io/v2/${chainId}?api-key=${apiKey}`;
+
+    try {
+      const response = await axios.post(
+        url,
+        {
+          method: 'eth_getCode',
+          params: [accountAddress, 'latest'],
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+
+      const bytecode = response.data?.result;
+      const isDeployed = bytecode && bytecode !== '0x';
+
+      // Setting the localStorageValue based on the deployment status
+      setWalletDeployedLocalStorageStatus(accountAddress, chainId, isDeployed);
+
+      return isDeployed;
+    } catch (error) {
+      console.error(
+        'isWalletDeployed: Failed to check if wallet is deployed',
+        error
+      );
+      return undefined;
+    }
+  };
+
+  const getWalletDeploymentCost = async ({
+    accountAddress,
+    chainId,
+  }: {
+    accountAddress: string;
+    chainId: number;
+  }): Promise<number> => {
+    try {
+      // Checking if wallet is already deployed with localStorage
+      const isDeployed = await isWalletDeployed(accountAddress, chainId);
+
+      if (isDeployed === undefined) {
+        console.error(
+          'getWalletDeploymentCost: Failed to check account deployment status'
+        );
+        return 0;
+      }
+
+      // Wallet is already deployed so no need to add extra gas cost
+      if (isDeployed) {
+        return 0;
+      }
+
+      // Wallet is not deployed so need to add extra gas cost
+      const gasPriceHex = await getGasPrice(chainId);
+
+      if (!gasPriceHex) {
+        console.error('getWalletDeploymentCost: Failed to fetch gas price');
+        return 0;
+      }
+
+      // Convert hex gas price to BigInt
+      const gasPrice = BigInt(gasPriceHex);
+
+      // This is a static gas unit for approx wallet deployment in "gas units" on all chains
+      const gasUnits = BigInt(271000);
+
+      // Calculate total gas cost in wei
+      const gasCostWei = gasPrice * gasUnits;
+
+      // Convert wei to ETH (18 decimals) and then to number
+      const gasCostInEth = formatEther(gasCostWei);
+
+      return parseFloat(gasCostInEth);
+    } catch (error) {
+      console.error(
+        'getWalletDeploymentCost: Error calculating deployment cost',
+        error
+      );
+      return 0;
+    }
+  };
+
+  // This is to clear the localStorageStatus if needed
+  const clearWalletDeployedLocalStorageStatus = (
+    accountAddress: string,
+    chainId: number
+  ) => {
+    try {
+      const localStorageKey = getWalletDeployedLocalStorageKey(
+        accountAddress,
+        chainId
+      );
+      localStorage.removeItem(localStorageKey);
+    } catch (error) {
+      console.warn('Failed to clear localStorageStatus:', error);
+    }
+  };
+
+  return {
+    getGasPrice,
+    isWalletDeployed,
+    getWalletDeploymentCost,
+    clearWalletDeployedLocalStorageStatus,
+  };
+};
+
+export default useDeployWallet;

--- a/src/services/tokensData.ts
+++ b/src/services/tokensData.ts
@@ -49,6 +49,8 @@ type TokenDataType = {
 let tokensData: Token[] = [];
 
 export const chainNameDataCompatibility = (chainName: string) => {
+  if (!chainName) return '';
+
   const chain = chainName.toLowerCase();
 
   if (chain === 'xdai') {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Implementation to limit the max amount spendable in Send Modal and The Exchange app for native/gas tokens on undeployed wallets

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Existing Unit Tests and Manual Testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Wallet deployment costs are now automatically detected and factored in when sending or swapping native tokens, ensuring users cannot exceed their actual available balance.
  - The app displays contextual error messages if a wallet is undeployed or while deployment cost information is loading.

- **Bug Fixes**
  - Improved handling of missing or invalid chain names to prevent potential errors in token-related operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->