### PR TITLE
fix/PRO-3505/add-extra-week-migration-board

### DIFF
--- a/src/apps/leaderboard/utils/index.tsx
+++ b/src/apps/leaderboard/utils/index.tsx
@@ -7,7 +7,7 @@ import {
 
 /**
  * Get the current week based on the current date
- * If goes after the 4 migration weeks it will return null
+ * If goes after the last migration week it will return the last week number
  */
 function getCurrentMigrationWeek(): number | null {
   const now = new Date();
@@ -16,13 +16,18 @@ function getCurrentMigrationWeek(): number | null {
   if (now >= new Date(2025, 5, 10) && now < new Date(2025, 5, 17)) return 2;
   if (now >= new Date(2025, 5, 17) && now < new Date(2025, 5, 24)) return 3;
   if (now >= new Date(2025, 5, 24) && now < new Date(2025, 6, 1)) return 4;
+  if (now >= new Date(2025, 6, 1) && now < new Date(2025, 6, 8)) return 5;
+  if (now >= new Date(2025, 6, 8) && now < new Date(2025, 6, 15)) return 6;
+  if (now >= new Date(2025, 6, 15) && now < new Date(2025, 6, 22)) return 7;
+  if (now >= new Date(2025, 6, 22) && now < new Date(2025, 6, 29)) return 8;
 
-  return null;
+  // If migration is over, always return the last week
+  return 8;
 }
 
 /**
  * Get the current migration week data week based on the migration week
- * If goes after the 4 migration weeks it will return undefined
+ * If goes after the last migration week it will return the last week data
  */
 export const getCurrentWeekMigrationData = (
   usersMigrationEntries: MigrationEntry[]
@@ -65,7 +70,7 @@ export const getCurrentWeekMigrationData = (
 
 /**
  * Get the last migration week data week based on the migration week
- * If goes after the 4 migration weeks it will return undefined
+ * If goes after the last migration week it will return the last week data
  */
 export const getLastWeekMigrationData = (
   usersMigrationEntries: MigrationEntry[]


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Added 4 extra weeks for migration board (until 29th of July 2025)
- After week 8 will continue to display week 8

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Existing Unit Tests and Manual Testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of migration weeks to ensure data for weeks 5 through 8 is included and that the latest week is shown if the current date is beyond the last migration week.

* **Documentation**
  * Updated comments to clarify behavior when the current date exceeds the defined migration weeks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->