### PR TITLE
chore/additional-px-points

### DIFF
--- a/src/apps/leaderboard/components/LeaderboardTab/LeaderboardTab.tsx
+++ b/src/apps/leaderboard/components/LeaderboardTab/LeaderboardTab.tsx
@@ -7,26 +7,15 @@ import {
   LeaderboardTableData,
 } from '../../../../types/api';
 
+// utils
+import { calculateFinalPxPoints } from '../../utils';
+import { formatAmountDisplay } from '../../../../utils/number';
+
 // components
 import Body from '../Typography/Body';
 import UserInfo from '../UserInfo/UserInfo';
 
-// utils
-import { formatAmountDisplay } from '../../../../utils/number';
 
-/**
- * Calculate final PX points by adding bonus points if eligible
- */
-const calculateFinalPxPoints = (
-  basePoints: number,
-  finalPxPointsAwardEligible?: boolean,
-  timeTab: 'all' | 'weekly' = 'all'
-): number => {
-  if (timeTab === 'all' && finalPxPointsAwardEligible === true) {
-    return basePoints + 200;
-  }
-  return basePoints;
-};
 
 type LeaderboardTabProps = {
   data: LeaderboardTableData[];
@@ -132,7 +121,8 @@ const LeaderboardTab = ({ data, timeTab }: LeaderboardTabProps) => {
                         calculateFinalPxPoints(
                           myRankData.totalPoints,
                           myRankData.finalPxPointsAwardEligible,
-                          timeTab
+                          timeTab,
+                          'trading'
                         )
                       ) || 0
                     )}
@@ -193,7 +183,8 @@ const LeaderboardTab = ({ data, timeTab }: LeaderboardTabProps) => {
                         calculateFinalPxPoints(
                           result.totalPoints,
                           result.finalPxPointsAwardEligible,
-                          timeTab
+                          timeTab,
+                          'migration'
                         )
                       ) || 0
                     )}{' '}

--- a/src/apps/leaderboard/components/LeaderboardTab/LeaderboardTab.tsx
+++ b/src/apps/leaderboard/components/LeaderboardTab/LeaderboardTab.tsx
@@ -14,11 +14,22 @@ import UserInfo from '../UserInfo/UserInfo';
 // utils
 import { formatAmountDisplay } from '../../../../utils/number';
 
-type LeaderboardTabProps = {
-  data: LeaderboardTableData[];
+/**
+ * Calculate final PX points by adding bonus points if eligible
+ */
+const calculateFinalPxPoints = (basePoints: number, finalPxPointsAwardEligible?: boolean, timeTab: 'all' | 'weekly' = 'all'): number => {
+  if (timeTab === 'all' && finalPxPointsAwardEligible === true) {
+    return basePoints + 200;
+  }
+  return basePoints;
 };
 
-const LeaderboardTab = ({ data }: LeaderboardTabProps) => {
+type LeaderboardTabProps = {
+  data: LeaderboardTableData[];
+  timeTab: 'all' | 'weekly';
+};
+
+const LeaderboardTab = ({ data, timeTab }: LeaderboardTabProps) => {
   const [visibleCount, setVisibleCount] = useState(10);
   const loadMoreRef = useRef(null);
   const walletAddress = useWalletAddress();
@@ -113,7 +124,7 @@ const LeaderboardTab = ({ data }: LeaderboardTabProps) => {
                 <div className="flex text-right desktop:gap-[14px] tablet:gap-[14px] mobile:gap-1 items-baseline justify-end">
                   <p className="font-normal desktop:text-[22px] tablet:text-[22px] mobile:text-sm text-white">
                     {formatAmountDisplay(
-                      Math.floor(myRankData.totalPoints) || 0
+                      Math.floor(calculateFinalPxPoints(myRankData.totalPoints, myRankData.finalPxPointsAwardEligible, timeTab)) || 0
                     )}
                   </p>
                   <p className="font-normal text-sm text-white">PX</p>
@@ -168,7 +179,7 @@ const LeaderboardTab = ({ data }: LeaderboardTabProps) => {
                 <div className="flex text-right desktop:gap-[14px] tablet:gap-[14px] mobile:gap-1 items-baseline justify-end">
                   <p className="font-normal desktop:text-[22px] tablet:text-[22px] mobile:text-sm text-white">
                     {formatAmountDisplay(
-                      Math.floor(result.totalPoints) || 0
+                      Math.floor(calculateFinalPxPoints(result.totalPoints, result.finalPxPointsAwardEligible, timeTab)) || 0
                     )}{' '}
                   </p>
                   <p className="font-normal text-sm text-white">PX</p>

--- a/src/apps/leaderboard/components/LeaderboardTab/LeaderboardTab.tsx
+++ b/src/apps/leaderboard/components/LeaderboardTab/LeaderboardTab.tsx
@@ -15,8 +15,6 @@ import { formatAmountDisplay } from '../../../../utils/number';
 import Body from '../Typography/Body';
 import UserInfo from '../UserInfo/UserInfo';
 
-
-
 type LeaderboardTabProps = {
   data: LeaderboardTableData[];
   timeTab: 'all' | 'weekly';

--- a/src/apps/leaderboard/components/LeaderboardTab/LeaderboardTab.tsx
+++ b/src/apps/leaderboard/components/LeaderboardTab/LeaderboardTab.tsx
@@ -17,7 +17,11 @@ import { formatAmountDisplay } from '../../../../utils/number';
 /**
  * Calculate final PX points by adding bonus points if eligible
  */
-const calculateFinalPxPoints = (basePoints: number, finalPxPointsAwardEligible?: boolean, timeTab: 'all' | 'weekly' = 'all'): number => {
+const calculateFinalPxPoints = (
+  basePoints: number,
+  finalPxPointsAwardEligible?: boolean,
+  timeTab: 'all' | 'weekly' = 'all'
+): number => {
   if (timeTab === 'all' && finalPxPointsAwardEligible === true) {
     return basePoints + 200;
   }
@@ -124,7 +128,13 @@ const LeaderboardTab = ({ data, timeTab }: LeaderboardTabProps) => {
                 <div className="flex text-right desktop:gap-[14px] tablet:gap-[14px] mobile:gap-1 items-baseline justify-end">
                   <p className="font-normal desktop:text-[22px] tablet:text-[22px] mobile:text-sm text-white">
                     {formatAmountDisplay(
-                      Math.floor(calculateFinalPxPoints(myRankData.totalPoints, myRankData.finalPxPointsAwardEligible, timeTab)) || 0
+                      Math.floor(
+                        calculateFinalPxPoints(
+                          myRankData.totalPoints,
+                          myRankData.finalPxPointsAwardEligible,
+                          timeTab
+                        )
+                      ) || 0
                     )}
                   </p>
                   <p className="font-normal text-sm text-white">PX</p>
@@ -179,7 +189,13 @@ const LeaderboardTab = ({ data, timeTab }: LeaderboardTabProps) => {
                 <div className="flex text-right desktop:gap-[14px] tablet:gap-[14px] mobile:gap-1 items-baseline justify-end">
                   <p className="font-normal desktop:text-[22px] tablet:text-[22px] mobile:text-sm text-white">
                     {formatAmountDisplay(
-                      Math.floor(calculateFinalPxPoints(result.totalPoints, result.finalPxPointsAwardEligible, timeTab)) || 0
+                      Math.floor(
+                        calculateFinalPxPoints(
+                          result.totalPoints,
+                          result.finalPxPointsAwardEligible,
+                          timeTab
+                        )
+                      ) || 0
                     )}{' '}
                   </p>
                   <p className="font-normal text-sm text-white">PX</p>

--- a/src/apps/leaderboard/components/LeaderboardTab/test/LeaderboardTab.test.tsx
+++ b/src/apps/leaderboard/components/LeaderboardTab/test/LeaderboardTab.test.tsx
@@ -39,7 +39,9 @@ describe('<LeaderboardTab />', () => {
   });
 
   it('renders correctly and matches snapshot', () => {
-    const tree = renderer.create(<LeaderboardTab data={mockData} timeTab="all" />).toJSON();
+    const tree = renderer
+      .create(<LeaderboardTab data={mockData} timeTab="all" />)
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
 

--- a/src/apps/leaderboard/components/LeaderboardTab/test/LeaderboardTab.test.tsx
+++ b/src/apps/leaderboard/components/LeaderboardTab/test/LeaderboardTab.test.tsx
@@ -39,18 +39,18 @@ describe('<LeaderboardTab />', () => {
   });
 
   it('renders correctly and matches snapshot', () => {
-    const tree = renderer.create(<LeaderboardTab data={mockData} />).toJSON();
+    const tree = renderer.create(<LeaderboardTab data={mockData} timeTab="all" />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('displays initial 10 items', () => {
-    render(<LeaderboardTab data={mockData} />);
+    render(<LeaderboardTab data={mockData} timeTab="all" />);
 
     expect(screen.getAllByTestId('leaderboard-user-data')).toHaveLength(10);
   });
 
   it('loads more items when clicking "Loading more"', () => {
-    render(<LeaderboardTab data={mockData} />);
+    render(<LeaderboardTab data={mockData} timeTab="all" />);
 
     const loadMoreDiv = screen.getByText(/Loading more/i);
     fireEvent.click(loadMoreDiv);
@@ -63,7 +63,7 @@ describe('<LeaderboardTab />', () => {
   });
 
   it('hides "Loading more" when all items are displayed', () => {
-    render(<LeaderboardTab data={mockData} />);
+    render(<LeaderboardTab data={mockData} timeTab="all" />);
 
     const loadMoreDiv = screen.getByText(/Loading more/i);
     fireEvent.click(loadMoreDiv); // Loading more to 20
@@ -77,7 +77,7 @@ describe('<LeaderboardTab />', () => {
       mockWalletAddress
     );
 
-    render(<LeaderboardTab data={mockData} />);
+    render(<LeaderboardTab data={mockData} timeTab="all" />);
 
     expect(screen.getByText('My rank')).toBeInTheDocument();
     expect(
@@ -88,13 +88,13 @@ describe('<LeaderboardTab />', () => {
   it('does not display "My rank" section if wallet address is not in the data', () => {
     vi.spyOn(TransactionKit, 'useWalletAddress').mockReturnValue('0xNotInData');
 
-    render(<LeaderboardTab data={mockData} />);
+    render(<LeaderboardTab data={mockData} timeTab="all" />);
 
     expect(screen.queryByText('My rank')).not.toBeInTheDocument();
   });
 
   it('hides the "Loading more" when all items are visible and no more data is available', () => {
-    render(<LeaderboardTab data={mockData} />);
+    render(<LeaderboardTab data={mockData} timeTab="all" />);
 
     const loadMoreDiv = screen.getByText(/Loading more/i);
     fireEvent.click(loadMoreDiv);

--- a/src/apps/leaderboard/components/Leaderboards/Leaderboards.tsx
+++ b/src/apps/leaderboard/components/Leaderboards/Leaderboards.tsx
@@ -13,6 +13,7 @@ interface LeaderboardsProps {
   data?: LeaderboardTableData[];
   errorMessage?: string;
   noDataMessage?: string;
+  timeTab: 'all' | 'weekly';
 }
 
 const Leaderboards = ({
@@ -22,6 +23,7 @@ const Leaderboards = ({
   data,
   errorMessage = 'Failed to load data. Please try again later.',
   noDataMessage = 'No available data.',
+  timeTab,
 }: LeaderboardsProps) => {
   // Loading State
   if (isLoading) {
@@ -46,7 +48,7 @@ const Leaderboards = ({
 
   // Success State with Data
   if (isSuccess && data && data.length > 0) {
-    return <LeaderboardTab data={data} />;
+    return <LeaderboardTab data={data} timeTab={timeTab} />;
   }
 
   // Success State but No Data

--- a/src/apps/leaderboard/components/Leaderboards/tests/Leaderboards.test.tsx
+++ b/src/apps/leaderboard/components/Leaderboards/tests/Leaderboards.test.tsx
@@ -21,7 +21,7 @@ describe('Leaderboards Component', () => {
   });
 
   it('renders 3 SkeletonLoader components when loading', () => {
-    render(<Leaderboards isLoading isError={false} isSuccess={false} />);
+    render(<Leaderboards isLoading isError={false} isSuccess={false} timeTab="all" />);
 
     expect(SkeletonLoader).toHaveBeenCalledTimes(3);
     expect(screen.getAllByText('SkeletonLoader Mock')).toHaveLength(3);
@@ -35,6 +35,7 @@ describe('Leaderboards Component', () => {
         isError
         isSuccess={false}
         errorMessage={customError}
+        timeTab="all"
       />
     );
 
@@ -42,7 +43,7 @@ describe('Leaderboards Component', () => {
   });
 
   it('renders default error message if errorMessage not provided', () => {
-    render(<Leaderboards isLoading={false} isError isSuccess={false} />);
+    render(<Leaderboards isLoading={false} isError isSuccess={false} timeTab="all" />);
 
     expect(
       screen.getByText('Failed to load data. Please try again later.')
@@ -63,11 +64,12 @@ describe('Leaderboards Component', () => {
         isError={false}
         isSuccess
         data={mockData}
+        timeTab="all"
       />
     );
 
     expect(screen.getByText('LeaderboardTab Mock')).toBeInTheDocument();
-    expect(LeaderboardTab).toHaveBeenCalledWith({ data: mockData }, {});
+    expect(LeaderboardTab).toHaveBeenCalledWith({ data: mockData, timeTab: 'all' }, {});
   });
 
   it('renders noDataMessage when success but no data', () => {
@@ -79,6 +81,7 @@ describe('Leaderboards Component', () => {
         isSuccess
         data={[]}
         noDataMessage={customNoData}
+        timeTab="all"
       />
     );
 
@@ -87,7 +90,7 @@ describe('Leaderboards Component', () => {
 
   it('renders default noDataMessage when none provided', () => {
     render(
-      <Leaderboards isLoading={false} isError={false} isSuccess data={[]} />
+      <Leaderboards isLoading={false} isError={false} isSuccess data={[]} timeTab="all" />
     );
 
     expect(screen.getByText('No available data.')).toBeInTheDocument();
@@ -95,7 +98,7 @@ describe('Leaderboards Component', () => {
 
   it('renders null if no matching state', () => {
     const { container } = render(
-      <Leaderboards isLoading={false} isError={false} isSuccess={false} />
+      <Leaderboards isLoading={false} isError={false} isSuccess={false} timeTab="all" />
     );
 
     expect(container.firstChild).toBeNull();

--- a/src/apps/leaderboard/components/Leaderboards/tests/Leaderboards.test.tsx
+++ b/src/apps/leaderboard/components/Leaderboards/tests/Leaderboards.test.tsx
@@ -21,7 +21,9 @@ describe('Leaderboards Component', () => {
   });
 
   it('renders 3 SkeletonLoader components when loading', () => {
-    render(<Leaderboards isLoading isError={false} isSuccess={false} timeTab="all" />);
+    render(
+      <Leaderboards isLoading isError={false} isSuccess={false} timeTab="all" />
+    );
 
     expect(SkeletonLoader).toHaveBeenCalledTimes(3);
     expect(screen.getAllByText('SkeletonLoader Mock')).toHaveLength(3);
@@ -43,7 +45,9 @@ describe('Leaderboards Component', () => {
   });
 
   it('renders default error message if errorMessage not provided', () => {
-    render(<Leaderboards isLoading={false} isError isSuccess={false} timeTab="all" />);
+    render(
+      <Leaderboards isLoading={false} isError isSuccess={false} timeTab="all" />
+    );
 
     expect(
       screen.getByText('Failed to load data. Please try again later.')
@@ -69,7 +73,10 @@ describe('Leaderboards Component', () => {
     );
 
     expect(screen.getByText('LeaderboardTab Mock')).toBeInTheDocument();
-    expect(LeaderboardTab).toHaveBeenCalledWith({ data: mockData, timeTab: 'all' }, {});
+    expect(LeaderboardTab).toHaveBeenCalledWith(
+      { data: mockData, timeTab: 'all' },
+      {}
+    );
   });
 
   it('renders noDataMessage when success but no data', () => {
@@ -90,7 +97,13 @@ describe('Leaderboards Component', () => {
 
   it('renders default noDataMessage when none provided', () => {
     render(
-      <Leaderboards isLoading={false} isError={false} isSuccess data={[]} timeTab="all" />
+      <Leaderboards
+        isLoading={false}
+        isError={false}
+        isSuccess
+        data={[]}
+        timeTab="all"
+      />
     );
 
     expect(screen.getByText('No available data.')).toBeInTheDocument();
@@ -98,7 +111,12 @@ describe('Leaderboards Component', () => {
 
   it('renders null if no matching state', () => {
     const { container } = render(
-      <Leaderboards isLoading={false} isError={false} isSuccess={false} timeTab="all" />
+      <Leaderboards
+        isLoading={false}
+        isError={false}
+        isSuccess={false}
+        timeTab="all"
+      />
     );
 
     expect(container.firstChild).toBeNull();

--- a/src/apps/leaderboard/components/PointsCards/OverviewPointsCard.tsx
+++ b/src/apps/leaderboard/components/PointsCards/OverviewPointsCard.tsx
@@ -4,6 +4,16 @@ import { LeaderboardTableData } from '../../../../types/api';
 // utils
 import { formatAmountDisplay } from '../../../../utils/number';
 
+/**
+ * Calculate final PX points by adding bonus points if eligible
+ */
+const calculateFinalPxPoints = (basePoints: number, finalPxPointsAwardEligible?: boolean, timeTab: 'all' | 'weekly' = 'all'): number => {
+  if (timeTab === 'all' && finalPxPointsAwardEligible === true) {
+    return basePoints + 200;
+  }
+  return basePoints;
+};
+
 // images
 import CurrentRankIcon from '../../images/current-rank-icon.svg';
 import EarnedLastWeekIcon from '../../images/earned-last-week-icon.svg';
@@ -16,10 +26,12 @@ import BodySmall from '../Typography/BodySmall';
 type OverviewPointsCardProps = {
   myAllTimeMerged: { entry: LeaderboardTableData | undefined; index: number };
   myWeeklyMerged: { entry: LeaderboardTableData | undefined; index: number };
+  timeTab: 'all' | 'weekly';
 };
 const OverviewPointsCard = ({
   myAllTimeMerged,
   myWeeklyMerged,
+  timeTab,
 }: OverviewPointsCardProps) => {
   return (
     <div className="flex flex-col w-full h-full rounded-[10px] bg-purple_medium/[.05] p-3 gap-3">
@@ -38,7 +50,7 @@ const OverviewPointsCard = ({
             {myAllTimeMerged.index === -1
               ? '-'
               : formatAmountDisplay(
-                  Math.floor(myAllTimeMerged.entry?.totalPoints || 0)
+                  Math.floor(calculateFinalPxPoints(myAllTimeMerged.entry?.totalPoints || 0, myAllTimeMerged.entry?.finalPxPointsAwardEligible, timeTab))
                 )}{' '}
             <span className="font-semibold text-white/[.5]">PX</span>
           </BodySmall>
@@ -87,7 +99,7 @@ const OverviewPointsCard = ({
             {myWeeklyMerged.index === -1
               ? '-'
               : formatAmountDisplay(
-                  Math.floor(myWeeklyMerged.entry?.totalPoints || 0)
+                  Math.floor(calculateFinalPxPoints(myWeeklyMerged.entry?.totalPoints || 0, myWeeklyMerged.entry?.finalPxPointsAwardEligible, timeTab))
                 )}{' '}
             <span className="font-semibold text-white/[.5]">PX</span>
           </BodySmall>

--- a/src/apps/leaderboard/components/PointsCards/OverviewPointsCard.tsx
+++ b/src/apps/leaderboard/components/PointsCards/OverviewPointsCard.tsx
@@ -4,16 +4,6 @@ import { LeaderboardTableData } from '../../../../types/api';
 // utils
 import { formatAmountDisplay } from '../../../../utils/number';
 
-/**
- * Calculate final PX points by adding bonus points if eligible
- */
-const calculateFinalPxPoints = (basePoints: number, finalPxPointsAwardEligible?: boolean, timeTab: 'all' | 'weekly' = 'all'): number => {
-  if (timeTab === 'all' && finalPxPointsAwardEligible === true) {
-    return basePoints + 200;
-  }
-  return basePoints;
-};
-
 // images
 import CurrentRankIcon from '../../images/current-rank-icon.svg';
 import EarnedLastWeekIcon from '../../images/earned-last-week-icon.svg';
@@ -22,6 +12,20 @@ import WeeklyRankIcon from '../../images/weekly-rank-icon.svg';
 
 // components
 import BodySmall from '../Typography/BodySmall';
+
+/**
+ * Calculate final PX points by adding bonus points if eligible
+ */
+const calculateFinalPxPoints = (
+  basePoints: number,
+  finalPxPointsAwardEligible?: boolean,
+  timeTab: 'all' | 'weekly' = 'all'
+): number => {
+  if (timeTab === 'all' && finalPxPointsAwardEligible === true) {
+    return basePoints + 200;
+  }
+  return basePoints;
+};
 
 type OverviewPointsCardProps = {
   myAllTimeMerged: { entry: LeaderboardTableData | undefined; index: number };
@@ -50,7 +54,13 @@ const OverviewPointsCard = ({
             {myAllTimeMerged.index === -1
               ? '-'
               : formatAmountDisplay(
-                  Math.floor(calculateFinalPxPoints(myAllTimeMerged.entry?.totalPoints || 0, myAllTimeMerged.entry?.finalPxPointsAwardEligible, timeTab))
+                  Math.floor(
+                    calculateFinalPxPoints(
+                      myAllTimeMerged.entry?.totalPoints || 0,
+                      myAllTimeMerged.entry?.finalPxPointsAwardEligible,
+                      timeTab
+                    )
+                  )
                 )}{' '}
             <span className="font-semibold text-white/[.5]">PX</span>
           </BodySmall>
@@ -99,7 +109,13 @@ const OverviewPointsCard = ({
             {myWeeklyMerged.index === -1
               ? '-'
               : formatAmountDisplay(
-                  Math.floor(calculateFinalPxPoints(myWeeklyMerged.entry?.totalPoints || 0, myWeeklyMerged.entry?.finalPxPointsAwardEligible, timeTab))
+                  Math.floor(
+                    calculateFinalPxPoints(
+                      myWeeklyMerged.entry?.totalPoints || 0,
+                      myWeeklyMerged.entry?.finalPxPointsAwardEligible,
+                      timeTab
+                    )
+                  )
                 )}{' '}
             <span className="font-semibold text-white/[.5]">PX</span>
           </BodySmall>

--- a/src/apps/leaderboard/components/PointsCards/OverviewPointsCard.tsx
+++ b/src/apps/leaderboard/components/PointsCards/OverviewPointsCard.tsx
@@ -97,9 +97,7 @@ const OverviewPointsCard = ({
             {myWeeklyMerged.index === -1
               ? '-'
               : formatAmountDisplay(
-                  Math.floor(
-                    myWeeklyMerged.entry?.totalPoints || 0
-                  )
+                  Math.floor(myWeeklyMerged.entry?.totalPoints || 0)
                 )}{' '}
             <span className="font-semibold text-white/[.5]">PX</span>
           </BodySmall>

--- a/src/apps/leaderboard/components/PointsCards/OverviewPointsCard.tsx
+++ b/src/apps/leaderboard/components/PointsCards/OverviewPointsCard.tsx
@@ -3,6 +3,7 @@ import { LeaderboardTableData } from '../../../../types/api';
 
 // utils
 import { formatAmountDisplay } from '../../../../utils/number';
+import { calculateFinalPxPoints } from '../../utils';
 
 // images
 import CurrentRankIcon from '../../images/current-rank-icon.svg';
@@ -12,20 +13,6 @@ import WeeklyRankIcon from '../../images/weekly-rank-icon.svg';
 
 // components
 import BodySmall from '../Typography/BodySmall';
-
-/**
- * Calculate final PX points by adding bonus points if eligible
- */
-const calculateFinalPxPoints = (
-  basePoints: number,
-  finalPxPointsAwardEligible?: boolean,
-  timeTab: 'all' | 'weekly' = 'all'
-): number => {
-  if (timeTab === 'all' && finalPxPointsAwardEligible === true) {
-    return basePoints + 200;
-  }
-  return basePoints;
-};
 
 type OverviewPointsCardProps = {
   myAllTimeMerged: { entry: LeaderboardTableData | undefined; index: number };
@@ -58,7 +45,8 @@ const OverviewPointsCard = ({
                     calculateFinalPxPoints(
                       myAllTimeMerged.entry?.totalPoints || 0,
                       myAllTimeMerged.entry?.finalPxPointsAwardEligible,
-                      timeTab
+                      timeTab,
+                      'migration'
                     )
                   )
                 )}{' '}
@@ -110,11 +98,7 @@ const OverviewPointsCard = ({
               ? '-'
               : formatAmountDisplay(
                   Math.floor(
-                    calculateFinalPxPoints(
-                      myWeeklyMerged.entry?.totalPoints || 0,
-                      myWeeklyMerged.entry?.finalPxPointsAwardEligible,
-                      timeTab
-                    )
+                    myWeeklyMerged.entry?.totalPoints || 0
                   )
                 )}{' '}
             <span className="font-semibold text-white/[.5]">PX</span>

--- a/src/apps/leaderboard/components/PointsCards/tests/OverviewPointsCard.test.tsx
+++ b/src/apps/leaderboard/components/PointsCards/tests/OverviewPointsCard.test.tsx
@@ -29,6 +29,7 @@ describe('OverviewPointsCard', () => {
       <OverviewPointsCard
         myAllTimeMerged={{ entry: myAllTimeMergedMock, index: 4 }}
         myWeeklyMerged={{ entry: myWeeklyMergedMock, index: 9 }}
+        timeTab="all"
       />
     );
     expect(container).toMatchSnapshot();
@@ -39,6 +40,7 @@ describe('OverviewPointsCard', () => {
       <OverviewPointsCard
         myAllTimeMerged={{ entry: undefined, index: -1 }}
         myWeeklyMerged={{ entry: undefined, index: -1 }}
+        timeTab="all"
       />
     );
     expect(container).toMatchSnapshot();
@@ -49,6 +51,7 @@ describe('OverviewPointsCard', () => {
       <OverviewPointsCard
         myAllTimeMerged={{ entry: myAllTimeMergedMock, index: 0 }}
         myWeeklyMerged={{ entry: myWeeklyMergedMock, index: 2 }}
+        timeTab="all"
       />
     );
 
@@ -69,6 +72,7 @@ describe('OverviewPointsCard', () => {
       <OverviewPointsCard
         myAllTimeMerged={{ entry: undefined, index: -1 }}
         myWeeklyMerged={{ entry: undefined, index: -1 }}
+        timeTab="all"
       />
     );
 

--- a/src/apps/leaderboard/components/PxPointsSummary/PxPointsSummary.tsx
+++ b/src/apps/leaderboard/components/PxPointsSummary/PxPointsSummary.tsx
@@ -143,11 +143,7 @@ const PxPointsSummary = ({
             title="Trading"
             icon={TradingIcon}
             background="bg-percentage_green/[.05]"
-            points={calculateFinalPxPoints(
-              myAllTimeTrading.entry?.totalPoints || 0,
-              myAllTimeTrading.entry?.finalPxPointsAwardEligible,
-              timeTab
-            )}
+            points={myAllTimeTrading.entry?.totalPoints}
             rank={
               myAllTimeTrading.index !== -1
                 ? myAllTimeTrading.index + 1

--- a/src/apps/leaderboard/components/PxPointsSummary/PxPointsSummary.tsx
+++ b/src/apps/leaderboard/components/PxPointsSummary/PxPointsSummary.tsx
@@ -15,12 +15,23 @@ import OverviewPointsCard from '../PointsCards/OverviewPointsCard';
 import PointsCard from '../PointsCards/PointsCard';
 import BodySmall from '../Typography/BodySmall';
 
+/**
+ * Calculate final PX points by adding bonus points if eligible
+ */
+const calculateFinalPxPoints = (basePoints: number, finalPxPointsAwardEligible?: boolean, timeTab: 'all' | 'weekly' = 'all'): number => {
+  if (timeTab === 'all' && finalPxPointsAwardEligible === true) {
+    return basePoints + 200;
+  }
+  return basePoints;
+};
+
 type PxPointsSummaryProps = {
   allTimeTradingData: LeaderboardTableData[] | undefined;
   allTimeMigrationData: LeaderboardTableData[] | undefined;
   mergedAllTimeData: LeaderboardTableData[] | undefined;
   mergedWeeklyTimeData: LeaderboardTableData[] | undefined;
   isUserInMigrationData: boolean;
+  timeTab: 'all' | 'weekly';
 };
 
 const PxPointsSummary = ({
@@ -29,6 +40,7 @@ const PxPointsSummary = ({
   mergedAllTimeData,
   mergedWeeklyTimeData,
   isUserInMigrationData,
+  timeTab,
 }: PxPointsSummaryProps) => {
   const walletAddress = useWalletAddress();
 
@@ -98,6 +110,7 @@ const PxPointsSummary = ({
           <OverviewPointsCard
             myAllTimeMerged={myAllTimeMerged}
             myWeeklyMerged={myWeeklyMerged}
+            timeTab={timeTab}
           />
         </div>
 
@@ -109,7 +122,7 @@ const PxPointsSummary = ({
               title="Migration"
               icon={MigrationIcon}
               background="bg-percentage_red/[.05]"
-              points={myAllTimeMigration.entry?.totalPoints}
+              points={calculateFinalPxPoints(myAllTimeMigration.entry?.totalPoints || 0, myAllTimeMigration.entry?.finalPxPointsAwardEligible, timeTab)}
               rank={
                 myAllTimeMigration.index !== -1
                   ? myAllTimeMigration.index + 1
@@ -122,7 +135,7 @@ const PxPointsSummary = ({
             title="Trading"
             icon={TradingIcon}
             background="bg-percentage_green/[.05]"
-            points={myAllTimeTrading.entry?.totalPoints}
+                          points={calculateFinalPxPoints(myAllTimeTrading.entry?.totalPoints || 0, myAllTimeTrading.entry?.finalPxPointsAwardEligible, timeTab)}
             rank={
               myAllTimeTrading.index !== -1
                 ? myAllTimeTrading.index + 1

--- a/src/apps/leaderboard/components/PxPointsSummary/PxPointsSummary.tsx
+++ b/src/apps/leaderboard/components/PxPointsSummary/PxPointsSummary.tsx
@@ -3,6 +3,9 @@ import { useWalletAddress } from '@etherspot/transaction-kit';
 // types
 import { LeaderboardTableData } from '../../../../types/api';
 
+// utils
+import { calculateFinalPxPoints } from '../../utils';
+
 // images
 import LotteryTicketIcon from '../../images/lottery-qualified-icon.png';
 import MigrationIcon from '../../images/migration-icon.svg';
@@ -14,20 +17,6 @@ import GasNewDropCard from '../PointsCards/GasNewDropCard';
 import OverviewPointsCard from '../PointsCards/OverviewPointsCard';
 import PointsCard from '../PointsCards/PointsCard';
 import BodySmall from '../Typography/BodySmall';
-
-/**
- * Calculate final PX points by adding bonus points if eligible
- */
-const calculateFinalPxPoints = (
-  basePoints: number,
-  finalPxPointsAwardEligible?: boolean,
-  timeTab: 'all' | 'weekly' = 'all'
-): number => {
-  if (timeTab === 'all' && finalPxPointsAwardEligible === true) {
-    return basePoints + 200;
-  }
-  return basePoints;
-};
 
 type PxPointsSummaryProps = {
   allTimeTradingData: LeaderboardTableData[] | undefined;
@@ -129,7 +118,8 @@ const PxPointsSummary = ({
               points={calculateFinalPxPoints(
                 myAllTimeMigration.entry?.totalPoints || 0,
                 myAllTimeMigration.entry?.finalPxPointsAwardEligible,
-                timeTab
+                timeTab,
+                'migration'
               )}
               rank={
                 myAllTimeMigration.index !== -1

--- a/src/apps/leaderboard/components/PxPointsSummary/PxPointsSummary.tsx
+++ b/src/apps/leaderboard/components/PxPointsSummary/PxPointsSummary.tsx
@@ -18,7 +18,11 @@ import BodySmall from '../Typography/BodySmall';
 /**
  * Calculate final PX points by adding bonus points if eligible
  */
-const calculateFinalPxPoints = (basePoints: number, finalPxPointsAwardEligible?: boolean, timeTab: 'all' | 'weekly' = 'all'): number => {
+const calculateFinalPxPoints = (
+  basePoints: number,
+  finalPxPointsAwardEligible?: boolean,
+  timeTab: 'all' | 'weekly' = 'all'
+): number => {
   if (timeTab === 'all' && finalPxPointsAwardEligible === true) {
     return basePoints + 200;
   }
@@ -122,7 +126,11 @@ const PxPointsSummary = ({
               title="Migration"
               icon={MigrationIcon}
               background="bg-percentage_red/[.05]"
-              points={calculateFinalPxPoints(myAllTimeMigration.entry?.totalPoints || 0, myAllTimeMigration.entry?.finalPxPointsAwardEligible, timeTab)}
+              points={calculateFinalPxPoints(
+                myAllTimeMigration.entry?.totalPoints || 0,
+                myAllTimeMigration.entry?.finalPxPointsAwardEligible,
+                timeTab
+              )}
               rank={
                 myAllTimeMigration.index !== -1
                   ? myAllTimeMigration.index + 1
@@ -135,7 +143,11 @@ const PxPointsSummary = ({
             title="Trading"
             icon={TradingIcon}
             background="bg-percentage_green/[.05]"
-                          points={calculateFinalPxPoints(myAllTimeTrading.entry?.totalPoints || 0, myAllTimeTrading.entry?.finalPxPointsAwardEligible, timeTab)}
+            points={calculateFinalPxPoints(
+              myAllTimeTrading.entry?.totalPoints || 0,
+              myAllTimeTrading.entry?.finalPxPointsAwardEligible,
+              timeTab
+            )}
             rank={
               myAllTimeTrading.index !== -1
                 ? myAllTimeTrading.index + 1

--- a/src/apps/leaderboard/components/PxPointsSummary/tests/PxPointsSummary.test.tsx
+++ b/src/apps/leaderboard/components/PxPointsSummary/tests/PxPointsSummary.test.tsx
@@ -124,6 +124,7 @@ describe('<PxPointsSummary />', () => {
         mergedAllTimeData={mergedAllTimeDataMock}
         mergedWeeklyTimeData={mergedWeeklyTimeDataMock}
         isUserInMigrationData
+        timeTab="all"
       />
     );
 
@@ -138,6 +139,7 @@ describe('<PxPointsSummary />', () => {
         mergedAllTimeData={mergedAllTimeDataMock}
         mergedWeeklyTimeData={mergedWeeklyTimeDataMock}
         isUserInMigrationData
+        timeTab="all"
       />
     );
 
@@ -157,6 +159,7 @@ describe('<PxPointsSummary />', () => {
         mergedAllTimeData={mergedAllTimeDataMock}
         mergedWeeklyTimeData={mergedWeeklyTimeDataMock}
         isUserInMigrationData={false}
+        timeTab="all"
       />
     );
 
@@ -178,6 +181,7 @@ describe('<PxPointsSummary />', () => {
         mergedAllTimeData={mergedAllTimeDataMock}
         mergedWeeklyTimeData={newMergedWeeklyTimeDataMock}
         isUserInMigrationData={false}
+        timeTab="all"
       />
     );
 
@@ -194,6 +198,7 @@ describe('<PxPointsSummary />', () => {
         mergedAllTimeData={[]}
         mergedWeeklyTimeData={[]}
         isUserInMigrationData={false}
+        timeTab="all"
       />
     );
 

--- a/src/apps/leaderboard/hooks/useLeaderboardData.tsx
+++ b/src/apps/leaderboard/hooks/useLeaderboardData.tsx
@@ -117,7 +117,8 @@ export const useLeaderboardData = () => {
             addresses: [currentUserData.address],
             completedSwap: currentUserData.completedSwap || false,
             rankChange,
-            finalPxPointsAwardEligible: currentUserData.finalPxPointsAwardEligible,
+            finalPxPointsAwardEligible:
+              currentUserData.finalPxPointsAwardEligible,
           };
         });
 

--- a/src/apps/leaderboard/hooks/useLeaderboardData.tsx
+++ b/src/apps/leaderboard/hooks/useLeaderboardData.tsx
@@ -69,6 +69,7 @@ export const useLeaderboardData = () => {
       totalGas: result.totalTxFeesUsd || 0,
       addresses: [result.address],
       newDropTime: result.pointsUpdatedAt || 0,
+      finalPxPointsAwardEligible: result.finalPxPointsAwardEligible,
     }));
   }, [allTimeQuery.data]);
 
@@ -116,6 +117,7 @@ export const useLeaderboardData = () => {
             addresses: [currentUserData.address],
             completedSwap: currentUserData.completedSwap || false,
             rankChange,
+            finalPxPointsAwardEligible: currentUserData.finalPxPointsAwardEligible,
           };
         });
 

--- a/src/apps/leaderboard/index.tsx
+++ b/src/apps/leaderboard/index.tsx
@@ -153,6 +153,7 @@ const App = () => {
         mergedAllTimeData={mergedAllTimeData}
         mergedWeeklyTimeData={mergedWeeklyTimeData}
         isUserInMigrationData={isUserInMigrationData}
+        timeTab={timeTab}
       />
 
       <div className="flex flex-col bg-container_grey desktop:px-6 desktop:pt-6 tablet:px-6 tablet:pt-6 mobile:p-4 pb-12 rounded-2xl mt-3">
@@ -208,6 +209,7 @@ const App = () => {
             data={weeklyTradingData}
             errorMessage="Failed to load weekly trading data. Please try again later."
             noDataMessage="No available leaderboard data for this week."
+            timeTab={timeTab}
           />
         )}
 
@@ -220,6 +222,7 @@ const App = () => {
             data={allTimeTradingData}
             errorMessage="Failed to load all-time trading data. Please try again later."
             noDataMessage="No available leaderboard data."
+            timeTab={timeTab}
           />
         )}
 
@@ -234,6 +237,7 @@ const App = () => {
               data={allTimeMigrationData}
               errorMessage="Failed to load migration data. Please try again later."
               noDataMessage="No available migration data."
+              timeTab={timeTab}
             />
           )}
 
@@ -248,6 +252,7 @@ const App = () => {
               data={weeklyMigrationData}
               errorMessage="Failed to load weekly migration data. Please try again later."
               noDataMessage="No available migration data for this week."
+              timeTab={timeTab}
             />
           )}
 
@@ -260,6 +265,7 @@ const App = () => {
             data={mergedAllTimeData}
             errorMessage="Failed to load leaderboard data. Please try again later."
             noDataMessage="No available leaderboard data."
+            timeTab={timeTab}
           />
         )}
 
@@ -272,6 +278,7 @@ const App = () => {
             data={mergedWeeklyTimeData}
             errorMessage="Failed to load weekly leaderboard data. Please try again later."
             noDataMessage="No available leaderboard data for this week."
+            timeTab={timeTab}
           />
         )}
       </div>

--- a/src/apps/leaderboard/utils/index.tsx
+++ b/src/apps/leaderboard/utils/index.tsx
@@ -248,11 +248,11 @@ export const calculateFinalPxPoints = (
   if (activeTab === 'trading' && timeTab === 'all') {
     return basePoints;
   }
-  
+
   // Add bonus points only if timeTab is 'all' and eligible
   if (timeTab === 'all' && finalPxPointsAwardEligible === true) {
     return basePoints + 200;
   }
-  
+
   return basePoints;
 };

--- a/src/apps/leaderboard/utils/index.tsx
+++ b/src/apps/leaderboard/utils/index.tsx
@@ -234,3 +234,25 @@ export const getMergeLeaderboardMigrationDataByAddresses = (
 
   return mergedData.sort((a, b) => b.totalPoints - a.totalPoints);
 };
+
+/**
+ * Calculate final PX points by adding bonus points if eligible
+ */
+export const calculateFinalPxPoints = (
+  basePoints: number,
+  finalPxPointsAwardEligible?: boolean,
+  timeTab: 'all' | 'weekly' = 'all',
+  activeTab?: 'trading' | 'migration'
+): number => {
+  // If activeTab is 'trading' and timeTab is 'all', don't add bonus points
+  if (activeTab === 'trading' && timeTab === 'all') {
+    return basePoints;
+  }
+  
+  // Add bonus points only if timeTab is 'all' and eligible
+  if (timeTab === 'all' && finalPxPointsAwardEligible === true) {
+    return basePoints + 200;
+  }
+  
+  return basePoints;
+};

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -479,6 +479,7 @@ export type PointsResult = {
   swapTxFeesUsd?: PointsChainData;
   completedSwap?: boolean;
   transactionHistory?: PointsTransactionHistoryItem;
+  finalPxPointsAwardEligible?: boolean;
 };
 
 export type PointsResultsData = {
@@ -870,4 +871,5 @@ export type LeaderboardTableData = {
   rankChange?: LeaderboardRankChange;
   source?: string | undefined;
   newDropTime?: number;
+  finalPxPointsAwardEligible?: boolean;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- New Features
  - PX points now reflect a 200-point bonus for eligible users in the “All-time” view; the “Weekly” view remains unchanged.
  - Time range (“All-time” vs “Weekly”) is propagated across leaderboard and points cards for consistent displays.
- Bug Fixes
  - Ensures “My rank” and list rankings show correctly formatted, non-negative PX points using the new calculation.
- Tests
  - Updated component tests to cover the new time range prop and bonus calculation.
- Chores
  - Expanded data types to include eligibility for the final PX points bonus.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Time-range ("All-time" vs "Weekly") is now used throughout leaderboards and summary cards to determine displayed PX values.
  - Eligible users may receive a 200-point final PX bonus in applicable contexts (not applied for trading in All-time view).

- Bug Fixes
  - "My rank" and leaderboard rows display consistent, floored, non-negative PX values.

- Tests
  - Component tests updated to include the new time-range prop.

- Chores
  - Data types extended to include final-PX eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->