### PR TITLE
Allow Google bot/crawler

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,17 @@
 # https://www.robotstxt.org/robotstxt.html
-User-agent: *
-Disallow: /
 
-# AdsBot crawlers must be named explicitly
+# Allow Googlebot
+User-agent: Googlebot
+Disallow:
+
+# Allow AdsBot (for Google Ads landing page checks)
 User-agent: AdsBot-Google
+Disallow:
+
+# Allow Google Search Console’s testing tool
+User-agent: Google-InspectionTool
+Disallow:
+
+# Block everyone
+User-agent: *
 Disallow: /


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Modified Robots.txt to allow Google bots

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated crawler rules to allow Googlebot, AdsBot-Google, and Google-InspectionTool to access the site.
  * Added a default block for all other user agents to reduce unwanted crawling.
  * Removed the previous blanket block that could prevent desired indexing.
  * Cleaned up outdated comments for clarity.
  * Impact: Improves Google indexing and ad verification while limiting non-Google crawlers, potentially enhancing performance and crawl budget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->