### PR TITLE
fix/paymaster-batch-cleanup

### DIFF
--- a/src/components/BottomMenuModal/SendModal/SendModalBatchesTabView.tsx
+++ b/src/components/BottomMenuModal/SendModal/SendModalBatchesTabView.tsx
@@ -80,6 +80,8 @@ const SendModalBatchesTabView = () => {
       if (!transactions.length) return;
       // Skip pulse-sell batches - they are handled directly in the Pulse app
       if (batchName.includes('pulse-sell')) return;
+      // Skip paymaster-batch - these are internal and should not be displayed in batches view
+      if (batchName === 'paymaster-batch') return;
       const { chainId } = transactions[0];
       if (typeof chainId !== 'number') return; // skip if chainId is undefined
       if (!grouped[chainId]) grouped[chainId] = [];

--- a/src/components/BottomMenuModal/SendModal/SendModalTokensTabView.tsx
+++ b/src/components/BottomMenuModal/SendModal/SendModalTokensTabView.tsx
@@ -1513,6 +1513,12 @@ const SendModalTokensTabView = ({ payload }: { payload?: SendModalData }) => {
       if (isPaymaster && selectedPaymasterAddress && selectedFeeAsset) {
         const batchName = 'paymaster-batch';
 
+        // Clear any existing paymaster batch before creating a new one
+        const existingBatches = kit.getState().batches;
+        if (existingBatches[batchName]) {
+          kit.batch({ batchName }).remove();
+        }
+
         // 1. Approval transaction
         kit
           .transaction({
@@ -1560,6 +1566,9 @@ const SendModalTokensTabView = ({ payload }: { payload?: SendModalData }) => {
             'Batch estimation error:',
             batchEstimate.batches[batchName]?.errorMessage
           );
+          // Clear the failed paymaster batch
+          kit.batch({ batchName }).remove();
+
           Sentry.captureMessage('Estimation error during send', {
             level: 'error',
             tags: {
@@ -1644,6 +1653,10 @@ const SendModalTokensTabView = ({ payload }: { payload?: SendModalData }) => {
             'Batch send error:',
             batchSend.batches[batchName]?.errorMessage
           );
+
+          // Clear the failed paymaster batch
+          kit.batch({ batchName }).remove();
+
           Sentry.captureMessage('Sending error during send', {
             level: 'error',
             tags: {
@@ -1687,6 +1700,10 @@ const SendModalTokensTabView = ({ payload }: { payload?: SendModalData }) => {
         const chainIdForTxHash = selectedAsset.chainId;
         if (!userOpHash) {
           transactionDebugLog('No userOpHash returned after batch send');
+
+          // Clear the failed paymaster batch
+          kit.batch({ batchName }).remove();
+
           Sentry.captureMessage('Failed to get UserOp hash', {
             level: 'error',
             tags: {

--- a/src/providers/GlobalTransactionsBatchProvider.tsx
+++ b/src/providers/GlobalTransactionsBatchProvider.tsx
@@ -76,9 +76,12 @@ const GlobalTransactionsBatchProvider = ({
         );
       });
 
-      // Filter out pulse-sell batches from the count - they are handled directly in the Pulse app
+      // Filter out pulse-sell and paymaster-batch from the count
+      // - pulse-sell batches are handled directly in the Pulse app
+      // - paymaster-batch are internal and should not be displayed in batch counts
       const filteredBatches = Object.keys(batches).filter(
-        (batchName) => !batchName.includes('pulse-sell')
+        (batchName) =>
+          !batchName.includes('pulse-sell') && batchName !== 'paymaster-batch'
       );
       setBatchCount(filteredBatches.length);
     }, 1000);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Fix for batches cleanup if gasless transaction (batch) fails

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Existing Unit Tests and Manual Testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Internal paymaster batches are no longer shown in batch lists or counted, ensuring accurate batch indicators and cleaner views.
  - Automatic cleanup of failed or stale paymaster batches across multiple error scenarios prevents phantom batches and stuck states.
  - Improved grouping logic in the batches tab for more consistent display.
  - More reliable send flow in the tokens tab by proactively removing conflicting paymaster batches before creation and after errors, reducing confusion and preventing unintended reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->