### PR TITLE
Fix Search to clear the token address from token-atlas

### DIFF
--- a/src/apps/pulse/components/Buy/Buy.tsx
+++ b/src/apps/pulse/components/Buy/Buy.tsx
@@ -11,7 +11,7 @@ import {
   useState,
 } from 'react';
 import { TailSpin } from 'react-loader-spinner';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Hex, getAddress, isAddress } from 'viem';
 import useTransactionKit from '../../../../hooks/useTransactionKit';
 import { useGetSearchTokensQuery } from '../../../../services/pillarXApiSearchTokens';
@@ -74,11 +74,16 @@ export default function Buy(props: BuyProps) {
 
   // Simple background search for token-atlas
   const location = useLocation();
+  const navigate = useNavigate();
   const query = new URLSearchParams(location.search);
   const tokenToSearch = query.get('asset');
   const blockchain = query.get('blockchain');
   const fromTokenAtlas = query.get('from') === 'token-atlas';
   const [isSearchingToken, setIsSearchingToken] = useState(false);
+
+  const removeQueryParams = () => {
+    navigate(location.pathname, { replace: true });
+  };
 
   const { data: searchData, isLoading: isSearchLoading } =
     useGetSearchTokensQuery(
@@ -386,8 +391,12 @@ export default function Buy(props: BuyProps) {
         }
 
         setIsSearchingToken(false);
+
+        // Clean up URL parameters after successfully selecting token from token-atlas
+        removeQueryParams();
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     fromTokenAtlas,
     tokenToSearch,

--- a/src/apps/pulse/components/Search/Search.tsx
+++ b/src/apps/pulse/components/Search/Search.tsx
@@ -121,7 +121,9 @@ export default function Search({
     inputRef.current?.focus();
     const tokenAddress = query.get('asset');
 
-    if (isAddress(tokenAddress || '')) {
+    // Only read asset parameter when in buy mode to prevent token address
+    // from token-atlas showing in sell search
+    if (isBuy && isAddress(tokenAddress || '')) {
       setSearchText(tokenAddress!);
     }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
-

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * After selecting a token, the app now cleans up the URL by removing temporary query parameters, providing cleaner, shareable links and smoother navigation.

* **Bug Fixes**
  * Sell mode searches no longer auto-populate from URL token parameters; token prefill from URL applies only in Buy mode, preventing incorrect asset selection and reducing confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->