### PR TITLE
Bug Fixes on Gasless

### DIFF
--- a/src/components/BottomMenuModal/AccountModal.tsx
+++ b/src/components/BottomMenuModal/AccountModal.tsx
@@ -66,7 +66,7 @@ const AccountModal = ({ isContentVisible }: AccountModalProps) => {
     isSuccess: isWalletPortfolioDataSuccess,
   } = useGetWalletPortfolioQuery(
     { wallet: accountAddress || '', isPnl: false },
-    { skip: !accountAddress, refetchOnFocus: true, pollingInterval: 120000 }
+    { skip: !accountAddress, refetchOnFocus: false }
   );
 
   const groupedTokens = useMemo(() => {

--- a/src/components/BottomMenuModal/SendModal/SendModalTokensTabView.tsx
+++ b/src/components/BottomMenuModal/SendModal/SendModalTokensTabView.tsx
@@ -202,7 +202,7 @@ const SendModalTokensTabView = ({ payload }: { payload?: SendModalData }) => {
       wallet: accountAddress || '',
       isPnl: false,
     },
-    { skip: !accountAddress }
+    { skip: !accountAddress, refetchOnFocus: false }
   );
 
   /**

--- a/src/components/Form/AssetSelect/index.tsx
+++ b/src/components/Form/AssetSelect/index.tsx
@@ -48,7 +48,7 @@ const AssetSelect = ({
     isSuccess: isWalletPortfolioDataSuccess,
   } = useGetWalletPortfolioQuery(
     { wallet: walletAddress || '', isPnl: false },
-    { skip: !walletAddress, refetchOnFocus: true, pollingInterval: 120000 }
+    { skip: !walletAddress, refetchOnFocus: false }
   );
 
   const assets = useMemo(() => {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- When it auto refreshes, the fee token address changes to the default first option even if user has selected another option so this PR addresses the issue on keeping the user selection as it is when it auto refreshes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Fee asset picker now restores your previously selected fee token when switching assets in Gasless mode, when available.

- Bug Fixes
  - Prevents unintended reset of the selected fee asset during asset switches.
  - Honors the current fee asset in default selections, falling back only when necessary.
  - Improved stability of fee selection persistence across payload-driven flows and related contexts.

- Chores
  - Reduced automatic portfolio refresh: removed periodic polling and refetch-on-focus for wallet portfolio queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->