### PR TITLE
Fix pulse beta toast message only on fresh render on feat/PRO-3749/pulse-beta-tag

### DIFF
--- a/src/apps/pulse/components/App/AppWrapper.tsx
+++ b/src/apps/pulse/components/App/AppWrapper.tsx
@@ -6,6 +6,7 @@ import { useGetWalletPortfolioQuery } from '../../../../services/pillarXApiWalle
 import { SelectedToken } from '../../types/tokens';
 import { MobulaChainNames } from '../../utils/constants';
 import Search from '../Search/Search';
+import PulseToast from '../Toast/PulseToast';
 import HomeScreen from './HomeScreen';
 
 export default function AppWrapper() {
@@ -14,6 +15,7 @@ export default function AppWrapper() {
   const [chains, setChains] = useState<MobulaChainNames>(MobulaChainNames.All);
   const [buyToken, setBuyToken] = useState<SelectedToken | null>(null);
   const [sellToken, setSellToken] = useState<SelectedToken | null>(null);
+  const [showBetaToast, setShowBetaToast] = useState(false);
 
   const { walletAddress: accountAddress } = useTransactionKit();
 
@@ -38,6 +40,11 @@ export default function AppWrapper() {
 
   const query = useQuery();
 
+  // Show beta toast every time Pulse app opens
+  useEffect(() => {
+    setShowBetaToast(true);
+  }, []);
+
   useEffect(() => {
     const tokenAddress = query.get('asset');
     const from = query.get('from');
@@ -59,30 +66,35 @@ export default function AppWrapper() {
     }
   }, [setSearching, query]);
 
-  return searching ? (
-    <Search
-      setSearching={setSearching}
-      isBuy={isBuy}
-      setBuyToken={setBuyToken}
-      setSellToken={setSellToken}
-      chains={chains}
-      setChains={setChains}
-      walletPortfolioData={walletPortfolioData?.result?.data}
-      walletPortfolioLoading={walletPortfolioLoading}
-      walletPortfolioFetching={walletPortfolioFetching}
-      walletPortfolioError={!!walletPortfolioError}
-      refetchWalletPortfolio={refetchWalletPortfolio}
-    />
-  ) : (
-    <HomeScreen
-      setSearching={setSearching}
-      buyToken={buyToken}
-      sellToken={sellToken}
-      isBuy={isBuy}
-      setIsBuy={setIsBuy}
-      refetchWalletPortfolio={refetchWalletPortfolio}
-      setBuyToken={setBuyToken}
-      setChains={setChains}
-    />
+  return (
+    <>
+      {showBetaToast && <PulseToast onClose={() => setShowBetaToast(false)} />}
+      {searching ? (
+        <Search
+          setSearching={setSearching}
+          isBuy={isBuy}
+          setBuyToken={setBuyToken}
+          setSellToken={setSellToken}
+          chains={chains}
+          setChains={setChains}
+          walletPortfolioData={walletPortfolioData?.result?.data}
+          walletPortfolioLoading={walletPortfolioLoading}
+          walletPortfolioFetching={walletPortfolioFetching}
+          walletPortfolioError={!!walletPortfolioError}
+          refetchWalletPortfolio={refetchWalletPortfolio}
+        />
+      ) : (
+        <HomeScreen
+          setSearching={setSearching}
+          buyToken={buyToken}
+          sellToken={sellToken}
+          isBuy={isBuy}
+          setIsBuy={setIsBuy}
+          refetchWalletPortfolio={refetchWalletPortfolio}
+          setBuyToken={setBuyToken}
+          setChains={setChains}
+        />
+      )}
+    </>
   );
 }

--- a/src/apps/pulse/components/App/HomeScreen.tsx
+++ b/src/apps/pulse/components/App/HomeScreen.tsx
@@ -27,7 +27,6 @@ import Refresh from '../Misc/Refresh';
 import Settings from '../Misc/Settings';
 import PreviewSell from '../Sell/PreviewSell';
 import Sell from '../Sell/Sell';
-import PulseToast from '../Toast/PulseToast';
 import TransactionStatus from '../Transaction/TransactionStatus';
 
 // hooks
@@ -92,7 +91,6 @@ export default function HomeScreen(props: HomeScreenProps) {
   const { walletAddress: accountAddress } = useTransactionKit();
   const { getBestSellOffer, isInitialized } = useRelaySell();
   const { intentSdk } = useIntentSdk();
-  const [showBetaToast, setShowBetaToast] = useState(false);
   const [previewBuy, setPreviewBuy] = useState(false);
   const [previewSell, setPreviewSell] = useState(false);
   const [transactionStatus, setTransactionStatus] = useState(false);
@@ -177,11 +175,6 @@ export default function HomeScreen(props: HomeScreenProps) {
       setTokenAmount('');
     }
   }, [isBuy, buyToken, payingTokens]);
-
-  // Show beta toast on every entry to Pulse
-  useEffect(() => {
-    setShowBetaToast(true);
-  }, []);
 
   const handleRefresh = useCallback(async () => {
     // Prevent multiple simultaneous refresh calls
@@ -957,7 +950,6 @@ export default function HomeScreen(props: HomeScreenProps) {
       style={{ backgroundColor: 'black' }}
       data-testid="pulse-home-view"
     >
-      {showBetaToast && <PulseToast onClose={() => setShowBetaToast(false)} />}
       {renderPreview()}
     </div>
   );

--- a/src/apps/pulse/components/App/tests/AppWrapper.test.tsx
+++ b/src/apps/pulse/components/App/tests/AppWrapper.test.tsx
@@ -285,4 +285,37 @@ describe('<AppWrapper />', () => {
     expect(screen.queryByTestId('pulse-search-view')).not.toBeInTheDocument();
     expect(screen.queryByTestId('pulse-search-modal')).not.toBeInTheDocument();
   });
+
+  it('shows beta toast when Pulse app opens', () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/']}>
+        <AppWrapper />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Welcome to Pulse (beta)')).toBeInTheDocument();
+  });
+
+  it('allows closing the beta toast', async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/']}>
+        <AppWrapper />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Welcome to Pulse (beta)')).toBeInTheDocument();
+
+    // Close the toast
+    const closeButton = screen.getByLabelText('Close');
+    closeButton.click();
+
+    // Wait for the animation to complete (300ms delay + some buffer)
+    await new Promise((resolve) => {
+      setTimeout(resolve, 400);
+    });
+
+    expect(
+      screen.queryByText('Welcome to Pulse (beta)')
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Show pulse beta toast message only on fresh render 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Existing Unit tests and manual testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds a dismissible “Welcome to Pulse (beta)” toast that appears when opening the Pulse app.
  - Toast displays above main content and can be closed at any time.
  - Ensures consistent toast behavior regardless of the initial screen.

- Tests
  - Added automated tests verifying the toast appears on app open and is removed after closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->