### PR TITLE
Sell quote and gas estimation pause fix

### DIFF
--- a/src/apps/pulse/hooks/useGasEstimation.ts
+++ b/src/apps/pulse/hooks/useGasEstimation.ts
@@ -15,12 +15,14 @@ interface UseGasEstimationProps {
   sellToken: SelectedToken | null;
   sellOffer: SellOffer | null;
   tokenAmount: string;
+  isPaused?: boolean;
 }
 
 export default function useGasEstimation({
   sellToken,
   sellOffer,
   tokenAmount,
+  isPaused = false,
 }: UseGasEstimationProps) {
   const [isEstimatingGas, setIsEstimatingGas] = useState(false);
   const [gasEstimationError, setGasEstimationError] = useState<string | null>(
@@ -41,7 +43,7 @@ export default function useGasEstimation({
     }
 
     // Prevent multiple simultaneous estimations
-    if (isEstimatingRef.current) {
+    if (isEstimatingRef.current || isPaused) {
       return;
     }
 
@@ -136,7 +138,7 @@ export default function useGasEstimation({
       isEstimatingRef.current = false;
       setIsEstimatingGas(false);
     }
-  }, [sellToken, kit, sellOffer, tokenAmount, buildSellTransactions]);
+  }, [sellToken, kit, sellOffer, tokenAmount, buildSellTransactions, isPaused]);
 
   // Store the latest function in ref to avoid infinite loops
   estimateGasFeesRef.current = estimateGasFees;
@@ -148,11 +150,12 @@ export default function useGasEstimation({
       sellToken &&
       kit &&
       tokenAmount &&
-      estimateGasFeesRef.current
+      estimateGasFeesRef.current &&
+      !isPaused
     ) {
       estimateGasFeesRef.current();
     }
-  }, [sellOffer, sellToken, kit, tokenAmount]);
+  }, [sellOffer, sellToken, kit, tokenAmount, isPaused]);
 
   return {
     isEstimatingGas,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
-

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The sell flow now intelligently pauses during critical steps (e.g., awaiting signature or executing), preventing background refreshes and gas re-calculations for a smoother, more stable experience.
  - The home screen reflects the paused state, keeping quotes and details consistent until actions complete.

- Bug Fixes
  - Prevents unexpected quote or gas updates while confirming/executing a sell, reducing interruptions and accidental retries.
  - Ensures the app reliably resumes normal updates after completion, errors, or navigation, avoiding lingering paused states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->