### PR TITLE
PRO-3691-BuyMinAmountChange

### DIFF
--- a/src/apps/pulse/components/Buy/Buy.tsx
+++ b/src/apps/pulse/components/Buy/Buy.tsx
@@ -175,7 +175,7 @@ export default function Buy(props: BuyProps) {
       if (usdAmount && !Number.isNaN(parseFloat(usdAmount))) {
         const amount = parseFloat(usdAmount);
 
-        if (amount < 0.5) {
+        if (amount < 2) {
           setBelowMinimumAmount(true);
           setNoEnoughLiquidity(false);
           setInsufficientWalletBalance(false);
@@ -583,7 +583,7 @@ export default function Buy(props: BuyProps) {
 
               let message = '';
               if (belowMinimumAmount) {
-                message = 'Min. amount 0.5 USD';
+                message = 'Min. amount 2 USD';
               } else if (insufficientWalletBalance) {
                 message = 'Insufficient wallet balance';
               } else if (notEnoughLiquidity && token) {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Changed the minimum amount of buy from 0.5 to 2USD and changed the warning message to the same

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested locally

## Screenshots (if appropriate):
<img width="538" height="494" alt="Screenshot 2025-10-07 at 4 39 27 PM" src="https://github.com/user-attachments/assets/c851157f-bb78-46cf-ba7c-9f050416c071" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the minimum purchase amount in the Buy flow to 2 USD to prevent very small transactions. Users entering less than 2 USD will see an updated error message and cannot proceed until the amount meets the threshold. Validation and UI feedback now consistently reflect the new limit across the input field and related checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->