### PR TITLE
Close upgrade completes or fails on feat/PRO-3797/7702-onboarding

### DIFF
--- a/src/components/EIP7702UpgradeModal/EIP7702UpgradeCloseButton.tsx
+++ b/src/components/EIP7702UpgradeModal/EIP7702UpgradeCloseButton.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+
+interface EIP7702UpgradeCloseButtonProps {
+  onClose: () => void;
+}
+
+const EIP7702UpgradeCloseButton = (props: EIP7702UpgradeCloseButtonProps) => {
+  const { onClose } = props;
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <button
+      className="flex items-center justify-center w-[36px] h-[34px] bg-[#1E1D24] rounded-[8px]"
+      onClick={onClose}
+      type="button"
+      aria-label="Close"
+    >
+      <svg
+        className="w-5 h-5 text-white/50"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M6 18L18 6M6 6l12 12"
+        />
+      </svg>
+    </button>
+  );
+};
+
+export default EIP7702UpgradeCloseButton;

--- a/src/components/EIP7702UpgradeModal/EIP7702UpgradeModal.tsx
+++ b/src/components/EIP7702UpgradeModal/EIP7702UpgradeModal.tsx
@@ -554,10 +554,7 @@ const EIP7702UpgradeModal: React.FC<EIP7702UpgradeModalProps> = ({
         className={`relative flex flex-col bg-[#1E1D24] rounded-2xl px-3 max-w-md mx-4 w-full items-center gap-9 max-h-[calc(100vh-6rem)] overflow-y-auto ${shouldShowLargePadding ? 'py-20' : 'py-6'}`}
       >
         {shouldShowCloseButton && (
-          <div
-            className="absolute top-4 right-4 justify-center items-center bg-[#121116] rounded-[10px] p-[2px_2px_4px_2px] flex w-10 h-10 ml-3"
-            data-testid="pulse-transaction-details-close-button"
-          >
+          <div className="absolute top-4 right-4 justify-center items-center bg-[#121116] rounded-[10px] p-[2px_2px_4px_2px] flex w-10 h-10 ml-3">
             <EIP7702UpgradeCloseButton onClose={onClose} />
           </div>
         )}

--- a/src/components/EIP7702UpgradeModal/EIP7702UpgradeModal.tsx
+++ b/src/components/EIP7702UpgradeModal/EIP7702UpgradeModal.tsx
@@ -23,6 +23,7 @@ import { UpgradeStatus, UserOpUpgradeStatus } from './types';
 
 // components
 import EIP7702UpgradeAction from './EIP7702UpgradeAction';
+import EIP7702UpgradeCloseButton from './EIP7702UpgradeCloseButton';
 import EIP7702UpgradeDetails from './EIP7702UpgradeDetails';
 import EIP7702UpgradeStatus from './EIP7702UpgradeStatus';
 
@@ -519,11 +520,26 @@ const EIP7702UpgradeModal: React.FC<EIP7702UpgradeModalProps> = ({
     );
   };
 
+  const handleBackdropClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.target !== event.currentTarget) {
+        return;
+      }
+
+      if (upgradeStatus === 'completed' || upgradeStatus === 'failed') {
+        onClose();
+      }
+    },
+    [onClose, upgradeStatus]
+  );
+
   // Early return after all hooks have been called
   if (!isOpen) return null;
 
   // Determine padding based on what's being shown
   const shouldShowLargePadding = !showDetails && upgradeStatus !== 'ready';
+  const shouldShowCloseButton =
+    upgradeStatus === 'completed' || upgradeStatus === 'failed';
 
   return (
     <div
@@ -532,10 +548,19 @@ const EIP7702UpgradeModal: React.FC<EIP7702UpgradeModalProps> = ({
         backgroundColor: 'rgba(18, 17, 22, 0.8)',
         backdropFilter: 'blur(10px)',
       }}
+      onClick={handleBackdropClick}
     >
       <div
-        className={`flex flex-col bg-[#1E1D24] rounded-2xl px-3 max-w-md mx-4 w-full items-center gap-9 max-h-[calc(100vh-6rem)] overflow-y-auto ${shouldShowLargePadding ? 'py-20' : 'py-6'}`}
+        className={`relative flex flex-col bg-[#1E1D24] rounded-2xl px-3 max-w-md mx-4 w-full items-center gap-9 max-h-[calc(100vh-6rem)] overflow-y-auto ${shouldShowLargePadding ? 'py-20' : 'py-6'}`}
       >
+        {shouldShowCloseButton && (
+          <div
+            className="absolute top-4 right-4 justify-center items-center bg-[#121116] rounded-[10px] p-[2px_2px_4px_2px] flex w-10 h-10 ml-3"
+            data-testid="pulse-transaction-details-close-button"
+          >
+            <EIP7702UpgradeCloseButton onClose={onClose} />
+          </div>
+        )}
         {renderContent()}
       </div>
     </div>

--- a/src/components/EIP7702UpgradeModal/tests/EIP7702UpgradeModal.test.tsx
+++ b/src/components/EIP7702UpgradeModal/tests/EIP7702UpgradeModal.test.tsx
@@ -109,13 +109,18 @@ vi.mock('../EIP7702UpgradeStatus', () => ({
   default: ({
     status,
     onViewDetails,
+    onClose,
   }: {
     status: string;
     onViewDetails: () => void;
+    onClose: () => void;
   }) => (
     <div data-testid={`upgrade-status-${status}`}>
       <button type="button" data-testid="view-details" onClick={onViewDetails}>
         View Details
+      </button>
+      <button type="button" data-testid="status-close" onClick={onClose}>
+        Close Status
       </button>
     </div>
   ),

--- a/src/components/EIP7702UpgradeModal/tests/__snapshots__/EIP7702UpgradeModal.test.tsx.snap
+++ b/src/components/EIP7702UpgradeModal/tests/__snapshots__/EIP7702UpgradeModal.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<EIP7702UpgradeModal /> > Rendering > renders correctly and matches snapshot 1`] = `
 <div
   className="fixed inset-0 flex items-center justify-center pt-4 pb-20 z-50"
+  onClick={[Function]}
   style={
     {
       "backdropFilter": "blur(10px)",
@@ -11,7 +12,7 @@ exports[`<EIP7702UpgradeModal /> > Rendering > renders correctly and matches sna
   }
 >
   <div
-    className="flex flex-col bg-[#1E1D24] rounded-2xl px-3 max-w-md mx-4 w-full items-center gap-9 max-h-[calc(100vh-6rem)] overflow-y-auto py-6"
+    className="relative flex flex-col bg-[#1E1D24] rounded-2xl px-3 max-w-md mx-4 w-full items-center gap-9 max-h-[calc(100vh-6rem)] overflow-y-auto py-6"
   >
     <div
       data-testid="upgrade-action"


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
-

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a close button overlay to the upgrade modal, shown when an upgrade completes or fails.
  * Modal can be dismissed by clicking the close button, clicking the backdrop, or pressing Escape.

* **Tests**
  * Updated modal tests to verify the new close behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->