### PR TITLE
Added condition to not show the message in EOA mode

### DIFF
--- a/src/apps/key-wallet/components/SendAssetModal.tsx
+++ b/src/apps/key-wallet/components/SendAssetModal.tsx
@@ -478,7 +478,7 @@ const SendAssetModal = ({
                   )
                 : !resolvedProvider && !isDelegatedEoa
                   ? 'Connecting...'
-                  : isWrongChain
+                  : isWrongChain && !isDelegatedEoa
                     ? `Switch & Send`
                     : 'Send'}
             </button>

--- a/src/apps/key-wallet/components/SendAssetModal.tsx
+++ b/src/apps/key-wallet/components/SendAssetModal.tsx
@@ -383,7 +383,7 @@ const SendAssetModal = ({
           </div>
 
           {/* Chain Warning */}
-          {isWrongChain && (
+          {isWrongChain && !isDelegatedEoa && (
             <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-xl p-3">
               <div className="flex items-start gap-2">
                 <span className="text-yellow-400 text-lg">⚠️</span>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Small update to not show the "Wrong Network" message and it's not relevant when connected via 7702 wallet

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chain warning in the asset transfer modal is now shown only when the wallet is on the wrong network and the account is not a delegated EOA, reducing unnecessary alerts.
  * Transfer button label now reads "Switch & Send" only when the wrong network warning applies; otherwise it displays "Send" for a clearer action.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->