### PR TITLE
Fixes/Relay_Buy

### DIFF
--- a/src/apps/pulse/components/App/HomeScreen.tsx
+++ b/src/apps/pulse/components/App/HomeScreen.tsx
@@ -110,6 +110,7 @@ export default function HomeScreen(props: HomeScreenProps) {
   const [maxStableCoinBalance, setMaxStableCoinBalance] = useState<{
     chainId: number;
     balance: number;
+    price?: number;
   }>();
   const [transactionData, setTransactionData] = useState<{
     sellToken: SelectedToken | null;
@@ -155,6 +156,7 @@ export default function HomeScreen(props: HomeScreenProps) {
   >(null);
   const [isSellFlowPaused, setIsSellFlowPaused] = useState<boolean>(false);
   const [isBuyFlowPaused, setIsBuyFlowPaused] = useState<boolean>(false);
+  const [usdcPrice, setUsdcPrice] = useState<number | undefined>();
 
   // Transaction status polling state
   const [currentTransactionStatus, setCurrentTransactionStatus] =
@@ -217,12 +219,22 @@ export default function HomeScreen(props: HomeScreenProps) {
     }
     const stableBalance =
       getStableCurrencyBalanceOnEachChain(walletPortfolioData);
-    const maxStableBalance = Math.max(...Object.values(stableBalance));
+    const maxStableBalance = Math.max(
+      ...Object.values(stableBalance).map((s) => s.balance)
+    );
     const chainIdOfMaxStableBalance = Number(
       Object.keys(stableBalance).find(
-        (key) => stableBalance[Number(key)] === maxStableBalance
+        (key) => stableBalance[Number(key)].balance === maxStableBalance
       ) || '1'
     );
+
+    // Set USDC price from the chain with max stable balance
+    const usdcPriceForMaxChain =
+      stableBalance[chainIdOfMaxStableBalance]?.price;
+    if (usdcPriceForMaxChain) {
+      setUsdcPrice(usdcPriceForMaxChain);
+    }
+
     setMaxStableCoinBalance({
       chainId: chainIdOfMaxStableBalance,
       balance: maxStableBalance,
@@ -962,6 +974,7 @@ export default function HomeScreen(props: HomeScreenProps) {
             onBuyOfferUpdate={handleBuyOfferUpdate}
             setBuyFlowPaused={setIsBuyFlowPaused}
             userPortfolio={portfolioTokens}
+            usdcPrice={usdcPrice}
           />
         </div>
       );
@@ -1126,6 +1139,7 @@ export default function HomeScreen(props: HomeScreenProps) {
                   setBuyRefreshCallback={setBuyRefreshCallback}
                   setBuyToken={setBuyToken}
                   setChains={setChains}
+                  usdcPrice={usdcPrice}
                 />
               ) : (
                 <Sell

--- a/src/apps/pulse/components/Buy/Buy.tsx
+++ b/src/apps/pulse/components/Buy/Buy.tsx
@@ -78,6 +78,7 @@ interface BuyProps {
   >;
   setBuyToken?: Dispatch<SetStateAction<SelectedToken | null>>;
   setChains: Dispatch<SetStateAction<MobulaChainNames>>;
+  usdcPrice?: number; // For Relay Buy: USDC price from portfolio (passed from HomeScreen)
 }
 
 export default function Buy(props: BuyProps) {
@@ -97,6 +98,7 @@ export default function Buy(props: BuyProps) {
     setChains,
     maxStableCoinBalance,
     customBuyAmounts,
+    usdcPrice,
   } = props;
   const [usdAmount, setUsdAmount] = useState<string>('');
   const [debouncedUsdAmount, setDebouncedUsdAmount] = useState<string>('');
@@ -291,6 +293,7 @@ export default function Buy(props: BuyProps) {
           toTokenAddress: token.address,
           toChainId: token.chainId,
           fromChainId: maxStableCoinBalance.chainId,
+          usdcPrice,
         });
 
         setBuyOffer(offer);
@@ -329,6 +332,7 @@ export default function Buy(props: BuyProps) {
     isRelayInitialized,
     getBestOffer,
     maxStableCoinBalance.chainId,
+    usdcPrice,
   ]);
 
   // Intent SDK: Refresh buy intent
@@ -797,6 +801,7 @@ export default function Buy(props: BuyProps) {
           payingTokens={payingTokens}
           token={token}
           usdAmount={usdAmount}
+          useRelayBuy={USE_RELAY_BUY}
         />
       </div>
     </div>

--- a/src/apps/pulse/components/Buy/PreviewBuy.tsx
+++ b/src/apps/pulse/components/Buy/PreviewBuy.tsx
@@ -67,6 +67,7 @@ interface PreviewBuyProps {
   onBuyOfferUpdate?: (offer: BuyOffer | null) => void; // For Relay Buy: callback to update offer
   setBuyFlowPaused?: (paused: boolean) => void; // For Relay Buy: pause background refresh
   userPortfolio?: Token[]; // For Relay Buy: user's token portfolio
+  usdcPrice?: number; // For Relay Buy: USDC price in USD (e.g., 0.9998)
 }
 
 export default function PreviewBuy(props: PreviewBuyProps) {
@@ -83,6 +84,7 @@ export default function PreviewBuy(props: PreviewBuyProps) {
     onBuyOfferUpdate,
     setBuyFlowPaused,
     userPortfolio,
+    usdcPrice,
   } = props;
 
   const [isLoading, setIsLoading] = useState(false);
@@ -534,6 +536,7 @@ export default function PreviewBuy(props: PreviewBuyProps) {
           toTokenAddress: buyToken.address,
           toChainId: buyToken.chainId,
           fromChainId,
+          usdcPrice,
         });
 
         onBuyOfferUpdate(newOffer);
@@ -624,6 +627,7 @@ export default function PreviewBuy(props: PreviewBuyProps) {
     estimateGasFees,
     cleanupBatch,
     USE_RELAY_BUY,
+    usdcPrice,
   ]);
 
   // Auto-refresh buy offer every 15 seconds (disabled when waiting for signature or executing)

--- a/src/apps/pulse/components/Buy/PreviewBuy.tsx
+++ b/src/apps/pulse/components/Buy/PreviewBuy.tsx
@@ -390,7 +390,8 @@ export default function PreviewBuy(props: PreviewBuyProps) {
         buyToken,
         usdAmount, // Pass USD amount, not token amount
         fromChainId,
-        userPortfolio
+        userPortfolio,
+        usdcPrice
       );
 
       if (result === true) {

--- a/src/apps/pulse/hooks/useRelayBuy.ts
+++ b/src/apps/pulse/hooks/useRelayBuy.ts
@@ -609,7 +609,8 @@ export default function useRelayBuy() {
     token: SelectedToken,
     amount: string,
     fromChainId: number,
-    userPortfolio?: Token[]
+    userPortfolio?: Token[],
+    usdcPrice?: number
   ): Promise<boolean | string> => {
     if (!isInitialized || !accountAddress || !walletAddress) {
       setError('Unable to execute transaction. Please try again.');
@@ -633,6 +634,7 @@ export default function useRelayBuy() {
         toTokenAddress: token.address,
         toChainId: token.chainId,
         fromChainId,
+        usdcPrice,
       });
 
       if (!buyOffer) {

--- a/src/apps/pulse/utils/parseSearchData.ts
+++ b/src/apps/pulse/utils/parseSearchData.ts
@@ -14,6 +14,30 @@ import {
 import { parseNumberString } from './number';
 import { isWrappedNativeToken } from '../../../utils/blockchain';
 
+// Optimism uses this special address for native ETH in Mobula API
+const OP_NATIVE_MOBULA = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const OPTIMISM_CHAIN_ID = 10;
+
+/**
+ * Normalize contract address for native tokens
+ * Optimism native ETH uses a special address in Mobula, we need to convert it to zero address
+ */
+const normalizeContractAddress = (
+  contract: string,
+  symbol: string,
+  chainId: number
+): string => {
+  if (
+    contract.toLowerCase() === OP_NATIVE_MOBULA.toLowerCase() &&
+    symbol === 'ETH' &&
+    chainId === OPTIMISM_CHAIN_ID
+  ) {
+    return ZERO_ADDRESS;
+  }
+  return contract;
+};
+
 export type Asset = {
   name: string;
   symbol: string;
@@ -42,6 +66,11 @@ export function parseAssetData(
     ) {
       const chainId = chainNameToChainIdTokensData(blockchains[i]);
       const contractAddress = contracts[i];
+      const normalizedContract = normalizeContractAddress(
+        contractAddress,
+        asset.symbol,
+        chainId
+      );
 
       // Filter out wrapped native tokens (WETH, WBNB, WPOL, etc.) from search results
       if (!isWrappedNativeToken(contractAddress, chainId)) {
@@ -55,7 +84,7 @@ export function parseAssetData(
           liquidity: asset.liquidity,
           chain: blockchains[i],
           decimals: decimals[i],
-          contract: contracts[i],
+          contract: normalizedContract,
           priceChange24h: asset.price_change_24h,
         });
       }
@@ -72,6 +101,11 @@ export function parseTokenData(asset: TokenAssetResponse): Asset[] {
     if (MOBULA_CHAIN_NAMES.includes(blockchains[i])) {
       const chainId = chainNameToChainIdTokensData(blockchains[i]);
       const contractAddress = contracts[i];
+      const normalizedContract = normalizeContractAddress(
+        contractAddress,
+        asset.symbol,
+        chainId
+      );
 
       // Filter out wrapped native tokens (WETH, WBNB, WPOL, etc.) from search results
       if (!isWrappedNativeToken(contractAddress, chainId)) {
@@ -85,7 +119,7 @@ export function parseTokenData(asset: TokenAssetResponse): Asset[] {
           liquidity: asset.liquidity,
           chain: blockchains[i],
           decimals: decimals[i],
-          contract: contracts[i],
+          contract: normalizedContract,
           priceChange24h: asset.price_change_24h,
         });
       }
@@ -121,12 +155,18 @@ export function parseFreshAndTrendingTokens(
     if (rows) {
       for (const j of rows) {
         const contractAddress = j.leftColumn?.line1?.copyLink || '';
+        const symbol = j.leftColumn?.line1?.text2 || '';
+        const normalizedContract = normalizeContractAddress(
+          contractAddress,
+          symbol,
+          +chainId
+        );
 
         // Filter out wrapped native tokens (WETH, WBNB, WPOL, etc.) from search results
         if (!isWrappedNativeToken(contractAddress, +chainId)) {
           res.push({
             chain: getChainName(+chainId),
-            contract: contractAddress,
+            contract: normalizedContract,
             decimals: j.meta?.tokenData.decimals || 18,
             liquidity: parseNumberString(
               j.leftColumn?.line2?.liquidity || '0.00K'
@@ -137,7 +177,7 @@ export function parseFreshAndTrendingTokens(
             priceChange24h:
               Number((j.rightColumn?.line1?.percentage || '0%').slice(0, -1)) *
               (j.rightColumn?.line1?.direction === 'DOWN' ? -1 : 1),
-            symbol: j.leftColumn?.line1?.text2 || '',
+            symbol,
             volume: parseNumberString(j.leftColumn?.line2?.volume || '0.00K'),
             mCap: j.meta?.tokenData.marketCap || 0,
             timestamp: j.leftColumn?.line2?.timestamp,

--- a/src/apps/pulse/utils/utils.tsx
+++ b/src/apps/pulse/utils/utils.tsx
@@ -217,16 +217,17 @@ export const canCloseTransaction = (
 // Helper function to calculate stable currency balance
 export const getStableCurrencyBalanceOnEachChain = (
   walletPortfolioData: WalletPortfolioMobulaResponse
-): { [chainId: number]: number } => {
+): { [chainId: number]: { balance: number; price?: number } } => {
   // get the list of chainIds from STABLE_CURRENCIES
   const chainIds = Array.from(
     new Set(STABLE_CURRENCIES.map((currency) => currency.chainId))
   );
 
   // create a map to hold the balance for each chainId
-  const balanceMap: { [chainId: number]: number } = {};
+  const balanceMap: { [chainId: number]: { balance: number; price?: number } } =
+    {};
   chainIds.forEach((chainId) => {
-    balanceMap[chainId] = 0;
+    balanceMap[chainId] = { balance: 0, price: undefined };
   });
   // calculate the balance for each chainId
   walletPortfolioData?.result.data.assets
@@ -251,7 +252,10 @@ export const getStableCurrencyBalanceOnEachChain = (
         const chainId = Number(contract.chainId.split(':').at(-1));
         const price = asset.price ?? 0;
         const balance = contract.balance ?? 0;
-        balanceMap[chainId] += price * balance;
+        balanceMap[chainId] = {
+          balance: price * balance,
+          price: asset.price ? asset.price : undefined,
+        };
       });
     });
 

--- a/src/hooks/useRemoteConfig.ts
+++ b/src/hooks/useRemoteConfig.ts
@@ -33,7 +33,7 @@ const getRelayBuyFromUrl = (): boolean | null => {
  */
 export const useRemoteConfig = () => {
   const [isInitialized, setIsInitialized] = useState(false);
-  const [useRelayBuy, setUseRelayBuy] = useState(false);
+  const [useRelayBuy, setUseRelayBuy] = useState(true);
 
   useEffect(() => {
     const initialize = async () => {

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -32,7 +32,7 @@ remoteConfig.settings = {
 
 // Set default values for remote config
 remoteConfig.defaultConfig = {
-  USE_RELAY_BUY: false,
+  USE_RELAY_BUY: true,
 };
 
 // Initialize and fetch remote config
@@ -59,6 +59,6 @@ export const getUseRelayBuyFlag = (): boolean => {
   } catch (error) {
     console.error('Failed to get USE_RELAY_BUY from Remote Config:', error);
     // Return default value
-    return false;
+    return true;
   }
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Enable Trading check should only show when the relayBuy is false
- Native Token Fix on OP only for pulse Search alone.
- Changed the token input to use token price on buy
- Fixed decimals on previewBuy

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay Buy is enabled by default and the buy flows now use propagated USDC price for more accurate quotes.

* **Improvements**
  * Token/address normalization improved for cross-chain and Optimism native tokens.
  * Portfolio balances now include optional per-chain price data for clearer value display.
  * Buy flow validation tightened to prevent invalid USD amounts and align button behavior with selected buy path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->