### PR TITLE
fix/PRO-3893/eligibility-7702-check-smart-account

### DIFF
--- a/src/hooks/tests/useWalletModeVerification.test.tsx
+++ b/src/hooks/tests/useWalletModeVerification.test.tsx
@@ -1,0 +1,803 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { EtherspotTransactionKit } from '@etherspot/transaction-kit';
+import { renderHook, waitFor } from '@testing-library/react';
+import { privateKeyToAccount } from 'viem/accounts';
+import { vi } from 'vitest';
+
+import { OUR_EIP7702_IMPLEMENTATION_ADDRESS } from '../../utils/eip7702Authorization';
+import { useWalletModeVerification } from '../useWalletModeVerification';
+
+vi.mock('viem', () => ({
+  createPublicClient: vi.fn(),
+  http: vi.fn(),
+}));
+
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: vi.fn(),
+}));
+
+vi.mock('../../utils/blockchain', () => ({
+  visibleChains: [
+    { id: 1, name: 'Ethereum', testnet: false },
+    { id: 137, name: 'Polygon', testnet: false },
+  ],
+}));
+
+vi.mock('../../utils/common', () => ({
+  sanitizeError: vi.fn((err: unknown) => {
+    if (err instanceof Error) return err.message;
+    return String(err);
+  }),
+}));
+
+const mockGetCode = vi.fn();
+const mockGetBalance = vi.fn();
+const mockPublicClient = {
+  getCode: mockGetCode,
+  getBalance: mockGetBalance,
+};
+
+const mockKit = {
+  getWalletAddress: vi.fn(),
+} as unknown as EtherspotTransactionKit;
+
+const TEST_PRIVATE_KEY =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const TEST_EOA_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+const TEST_SMART_CONTRACT_ADDRESS =
+  '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const TEST_COUNTERFACTUAL_ADDRESS =
+  '0x1234567890123456789012345678901234567890';
+const TEST_EIP7702_CODE = `0xef0100${OUR_EIP7702_IMPLEMENTATION_ADDRESS.slice(2)}`;
+const TEST_OTHER_CONTRACT_CODE = '0x6080604052348015600f57600080fd5b50';
+
+describe('useWalletModeVerification', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const { createPublicClient } = await import('viem');
+    (createPublicClient as any).mockReturnValue(mockPublicClient);
+
+    (mockKit.getWalletAddress as any).mockResolvedValue(
+      TEST_COUNTERFACTUAL_ADDRESS
+    );
+
+    (privateKeyToAccount as any).mockReturnValue({
+      address: TEST_EOA_ADDRESS,
+    });
+  });
+
+  describe('Smart Contract Detection', () => {
+    it('should detect when eoaAddress is a smart contract and skip EIP-7702 check', async () => {
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      mockGetCode
+        .mockResolvedValueOnce(TEST_OTHER_CONTRACT_CODE)
+        .mockResolvedValue('0x')
+        .mockResolvedValue(BigInt(0));
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_SMART_CONTRACT_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('modular');
+        expect(result.current.eip7702Info).toEqual({});
+        expect(result.current.error).toBeNull();
+      });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('is a smart contract, not an EOA')
+      );
+      expect(mockGetCode).toHaveBeenCalledWith({
+        address: TEST_SMART_CONTRACT_ADDRESS,
+      });
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should not treat EIP-7702 code as a smart contract', async () => {
+      mockGetCode
+        .mockResolvedValueOnce(TEST_EIP7702_CODE)
+        .mockResolvedValue('0x')
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('delegatedEoa');
+      });
+
+      const firstCall = mockGetCode.mock.calls[0];
+      expect(firstCall[0].address).toBe(TEST_EOA_ADDRESS);
+    });
+
+    it('should treat empty code (0x) as EOA', async () => {
+      mockGetCode
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValue('0x')
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('delegatedEoa');
+      });
+    });
+  });
+
+  describe('EOA Address Resolution', () => {
+    it('should use eoaAddress prop when provided', async () => {
+      mockGetCode.mockResolvedValue('0x');
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBeDefined();
+      });
+
+      const firstCall = mockGetCode.mock.calls[0];
+      expect(firstCall[0].address).toBe(TEST_EOA_ADDRESS);
+    });
+
+    it('should derive EOA from privateKey when eoaAddress not provided', async () => {
+      mockGetCode.mockResolvedValue('0x');
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          privateKey: TEST_PRIVATE_KEY,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBeDefined();
+      });
+
+      expect(privateKeyToAccount).toHaveBeenCalledWith(TEST_PRIVATE_KEY);
+      const firstCall = mockGetCode.mock.calls[0];
+      expect(firstCall[0].address).toBe(TEST_EOA_ADDRESS);
+    });
+
+    it('should prioritize eoaAddress over privateKey', async () => {
+      const customEoaAddress = '0x9999999999999999999999999999999999999999';
+      mockGetCode.mockResolvedValue('0x');
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          privateKey: TEST_PRIVATE_KEY,
+          eoaAddress: customEoaAddress,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBeDefined();
+      });
+
+      const firstCall = mockGetCode.mock.calls[0];
+      expect(firstCall[0].address).toBe(customEoaAddress);
+    });
+
+    it('should set error when no EOA address is available', async () => {
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('modular');
+        expect(result.current.eip7702Info).toEqual({});
+      });
+
+      expect(mockGetCode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Smart Account Deployment Checks', () => {
+    it('should remain modular when smart account is deployed', async () => {
+      mockGetCode
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x1234')
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('modular');
+        expect(result.current.eip7702Info).toEqual({});
+      });
+    });
+
+    it('should remain modular when smart account has balance', async () => {
+      mockGetCode.mockResolvedValueOnce('0x').mockResolvedValue('0x');
+
+      mockGetBalance
+        .mockResolvedValueOnce(BigInt(1000000000000000000))
+        .mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('modular');
+        expect(result.current.eip7702Info).toEqual({});
+      });
+    });
+  });
+
+  describe('EIP-7702 Detection', () => {
+    it('should detect EIP-7702 implementation on EOA', async () => {
+      mockGetCode
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce(TEST_EIP7702_CODE)
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('delegatedEoa');
+        expect(result.current.eip7702Info[1]).toMatchObject({
+          hasImplementation: true,
+          isOurImplementation: true,
+          isOtherImplementation: false,
+        });
+        expect(
+          result.current.eip7702Info[1].delegateAddress?.toLowerCase()
+        ).toBe(OUR_EIP7702_IMPLEMENTATION_ADDRESS.toLowerCase());
+      });
+    });
+
+    it('should detect other EIP-7702 implementation', async () => {
+      const otherImplementation = '0x2222222222222222222222222222222222222222';
+      const otherEip7702Code = `0xef0100${otherImplementation.slice(2)}`;
+
+      mockGetCode
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce(otherEip7702Code)
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('delegatedEoa');
+        expect(result.current.eip7702Info[1]).toEqual({
+          hasImplementation: true,
+          isOurImplementation: false,
+          isOtherImplementation: true,
+          delegateAddress: otherImplementation.toLowerCase(),
+        });
+      });
+    });
+
+    it('should handle no EIP-7702 implementation', async () => {
+      mockGetCode
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('delegatedEoa');
+        expect(result.current.eip7702Info[1]).toEqual({
+          hasImplementation: false,
+          isOurImplementation: false,
+          isOtherImplementation: false,
+          delegateAddress: null,
+        });
+      });
+    });
+  });
+
+  describe('Smart Contract Detection - Additional Cases', () => {
+    it('should detect smart contract when privateKey derives contract address', async () => {
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      const contractAddress = '0xContractFromPrivateKey';
+      (privateKeyToAccount as any).mockReturnValue({
+        address: contractAddress,
+      });
+
+      mockGetCode
+        .mockResolvedValueOnce(TEST_OTHER_CONTRACT_CODE)
+        .mockResolvedValue('0x');
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          privateKey: TEST_PRIVATE_KEY,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('modular');
+        expect(result.current.eip7702Info).toEqual({});
+      });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('is a smart contract, not an EOA')
+      );
+      expect(mockKit.getWalletAddress).not.toHaveBeenCalled();
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should NOT call getWalletAddress when contract is detected', async () => {
+      mockGetCode.mockResolvedValueOnce(TEST_OTHER_CONTRACT_CODE);
+
+      renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_SMART_CONTRACT_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(mockGetCode).toHaveBeenCalled();
+      });
+
+      expect(mockKit.getWalletAddress).not.toHaveBeenCalled();
+    });
+
+    it('should handle getCode returning undefined', async () => {
+      mockGetCode.mockResolvedValueOnce(undefined).mockResolvedValue('0x');
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBeDefined();
+      });
+
+      expect(result.current.walletMode).toBe('delegatedEoa');
+    });
+
+    it('should handle both privateKey and eoaAddress where eoaAddress is contract', async () => {
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      mockGetCode.mockResolvedValueOnce(TEST_OTHER_CONTRACT_CODE);
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          privateKey: TEST_PRIVATE_KEY,
+          eoaAddress: TEST_SMART_CONTRACT_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('modular');
+      });
+
+      const firstCall = mockGetCode.mock.calls[0];
+      expect(firstCall[0].address).toBe(TEST_SMART_CONTRACT_ADDRESS);
+      expect(mockKit.getWalletAddress).not.toHaveBeenCalled();
+
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('Loading State', () => {
+    it('should set isLoading to true initially', async () => {
+      mockGetCode.mockResolvedValue('0x');
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      expect(result.current.isLoading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+    });
+
+    it('should set isLoading to false after contract detection', async () => {
+      mockGetCode.mockResolvedValueOnce(TEST_OTHER_CONTRACT_CODE);
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_SMART_CONTRACT_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+    });
+  });
+
+  describe('Multiple Chains', () => {
+    it('should check deployment across all visible chains', async () => {
+      mockGetCode
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x1234')
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('modular');
+      });
+
+      expect(mockGetCode).toHaveBeenCalledTimes(3);
+      expect(mockGetBalance).toHaveBeenCalled();
+    });
+
+    it('should check EIP-7702 across all chains', async () => {
+      mockGetCode
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce(TEST_EIP7702_CODE)
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.eip7702Info[1]).toBeDefined();
+        expect(result.current.eip7702Info[137]).toBeDefined();
+      });
+
+      expect(result.current.eip7702Info[1].hasImplementation).toBe(true);
+    });
+
+    it('should handle EIP-7702 on one chain but not others', async () => {
+      mockGetCode
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce(TEST_EIP7702_CODE)
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('delegatedEoa');
+      });
+
+      expect(result.current.eip7702Info[1].hasImplementation).toBe(true);
+      expect(result.current.eip7702Info[137].hasImplementation).toBe(false);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle getWalletAddress() error after validation', async () => {
+      mockGetCode.mockResolvedValueOnce('0x').mockResolvedValue('0x');
+      mockGetBalance.mockResolvedValue(BigInt(0));
+      (mockKit.getWalletAddress as any).mockRejectedValueOnce(
+        new Error('getWalletAddress failed')
+      );
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+        expect(result.current.walletMode).toBe('modular');
+      });
+    });
+
+    it('should handle error in deployment checks', async () => {
+      mockGetCode
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+        expect(result.current.walletMode).toBe('modular');
+      });
+    });
+
+    it('should handle error in EIP-7702 checks', async () => {
+      mockGetCode
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+        expect(result.current.walletMode).toBe('modular');
+      });
+    });
+
+    it('should handle getCode error during contract detection', async () => {
+      mockGetCode.mockRejectedValueOnce(new Error('RPC error'));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+        expect(result.current.walletMode).toBe('modular');
+      });
+    });
+  });
+
+  describe('EIP-7702 Code Parsing', () => {
+    it('should handle malformed EIP-7702 code', async () => {
+      const malformedCode = '0xef0100'; // Missing delegate address
+
+      mockGetCode
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce(malformedCode)
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('delegatedEoa');
+      });
+
+      expect(result.current.eip7702Info[1].delegateAddress).toBeNull();
+    });
+
+    it('should extract delegate address correctly from EIP-7702 code', async () => {
+      const customDelegate = '0x3333333333333333333333333333333333333333';
+      const eip7702Code = `0xef0100${customDelegate.slice(2)}`;
+
+      mockGetCode
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce('0x')
+        .mockResolvedValueOnce(eip7702Code)
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.eip7702Info[1].delegateAddress).toBe(
+          customDelegate.toLowerCase()
+        );
+      });
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle missing kit', async () => {
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: null,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('modular');
+        expect(result.current.eip7702Info).toEqual({});
+      });
+    });
+
+    it('should handle errors gracefully', async () => {
+      const error = new Error('Network error');
+      mockGetCode.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+        expect(result.current.walletMode).toBe('modular');
+      });
+    });
+
+    it('should check mainnet first for smart contract detection', async () => {
+      mockGetCode
+        .mockResolvedValueOnce(TEST_OTHER_CONTRACT_CODE)
+        .mockResolvedValue('0x');
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_SMART_CONTRACT_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(mockGetCode).toHaveBeenCalled();
+      });
+
+      const firstCall = mockGetCode.mock.calls[0];
+      expect(firstCall[0].address).toBe(TEST_SMART_CONTRACT_ADDRESS);
+    });
+
+    it('should handle chain fallback when mainnet not available', async () => {
+      vi.doMock('../../utils/blockchain', () => ({
+        visibleChains: [{ id: 137, name: 'Polygon', testnet: false }],
+      }));
+
+      mockGetCode.mockResolvedValueOnce('0x').mockResolvedValue('0x');
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBeDefined();
+      });
+    });
+
+    it('should clear error on successful verification', async () => {
+      mockGetCode.mockResolvedValue('0x');
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(
+        ({ eoaAddress }) =>
+          useWalletModeVerification({
+            eoaAddress,
+            kit: mockKit,
+          }),
+        {
+          initialProps: { eoaAddress: TEST_EOA_ADDRESS },
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('delegatedEoa');
+        expect(result.current.error).toBeNull();
+      });
+    });
+  });
+});

--- a/src/hooks/tests/useWalletModeVerification.test.tsx
+++ b/src/hooks/tests/useWalletModeVerification.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-plusplus */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { EtherspotTransactionKit } from '@etherspot/transaction-kit';
 import { renderHook, waitFor } from '@testing-library/react';
@@ -37,6 +38,26 @@ const mockPublicClient = {
   getBalance: mockGetBalance,
 };
 
+// Helper to setup mockGetCode responses in a clear, grouped way
+// Responses are returned in order: first all EOA checks (one per chain), then all counterfactual checks (one per chain)
+const setupMockGetCode = (config: {
+  eoaResponses: string[]; // Responses for EOA address checks, one per chain in visibleChains order
+  counterfactualResponses?: string[]; // Responses for counterfactual address checks, one per chain
+  defaultResponse?: string; // Default response if queue runs out
+}) => {
+  const responses: string[] = [
+    ...config.eoaResponses,
+    ...(config.counterfactualResponses || []),
+  ];
+  let callIndex = 0;
+
+  mockGetCode.mockImplementation(() => {
+    const response = responses[callIndex] ?? config.defaultResponse ?? '0x';
+    callIndex++;
+    return Promise.resolve(response);
+  });
+};
+
 const mockKit = {
   getWalletAddress: vi.fn(),
 } as unknown as EtherspotTransactionKit;
@@ -73,12 +94,9 @@ describe('useWalletModeVerification', () => {
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
 
-      mockGetCode
-        .mockResolvedValueOnce(TEST_OTHER_CONTRACT_CODE)
-        .mockResolvedValue('0x')
-        .mockResolvedValue(BigInt(0));
-
-      mockGetBalance.mockResolvedValue(BigInt(0));
+      setupMockGetCode({
+        eoaResponses: [TEST_OTHER_CONTRACT_CODE, '0x'], // Chain 1: contract, Chain 137: EOA
+      });
 
       const { result } = renderHook(() =>
         useWalletModeVerification({
@@ -93,21 +111,51 @@ describe('useWalletModeVerification', () => {
         expect(result.current.error).toBeNull();
       });
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('is a smart contract, not an EOA')
-      );
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      const warningMessage = consoleWarnSpy.mock.calls[0][0] as string;
+      expect(warningMessage).toContain('is a smart contract');
+      expect(warningMessage).toContain('not an EOA');
+      expect(warningMessage).toContain('chain(s): 1');
+      expect(mockGetCode).toHaveBeenCalledTimes(2);
       expect(mockGetCode).toHaveBeenCalledWith({
         address: TEST_SMART_CONTRACT_ADDRESS,
       });
+      expect(mockKit.getWalletAddress).not.toHaveBeenCalled();
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should detect contract on multiple chains', async () => {
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      setupMockGetCode({
+        eoaResponses: [TEST_OTHER_CONTRACT_CODE, TEST_OTHER_CONTRACT_CODE], // Contract on both chains
+      });
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_SMART_CONTRACT_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('modular');
+      });
+
+      const warningMessage = consoleWarnSpy.mock.calls[0][0] as string;
+      expect(warningMessage).toContain('chain(s): 1, 137');
 
       consoleWarnSpy.mockRestore();
     });
 
     it('should not treat EIP-7702 code as a smart contract', async () => {
-      mockGetCode
-        .mockResolvedValueOnce(TEST_EIP7702_CODE)
-        .mockResolvedValue('0x')
-        .mockResolvedValue('0x');
+      setupMockGetCode({
+        eoaResponses: [TEST_EIP7702_CODE, '0x'], // Chain 1: EIP-7702, Chain 137: EOA
+        counterfactualResponses: ['0x', '0x'], // Not deployed on either chain
+      });
 
       mockGetBalance.mockResolvedValue(BigInt(0));
 
@@ -122,15 +170,36 @@ describe('useWalletModeVerification', () => {
         expect(result.current.walletMode).toBe('delegatedEoa');
       });
 
-      const firstCall = mockGetCode.mock.calls[0];
-      expect(firstCall[0].address).toBe(TEST_EOA_ADDRESS);
+      expect(mockGetCode).toHaveBeenCalledWith({
+        address: TEST_EOA_ADDRESS,
+      });
     });
 
     it('should treat empty code (0x) as EOA', async () => {
-      mockGetCode
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValue('0x')
-        .mockResolvedValue('0x');
+      setupMockGetCode({
+        eoaResponses: ['0x', '0x'], // EOA on both chains
+        counterfactualResponses: ['0x', '0x'], // Not deployed on either chain
+      });
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('delegatedEoa');
+      });
+    });
+
+    it('should handle undefined code as EOA', async () => {
+      setupMockGetCode({
+        eoaResponses: [undefined as any, '0x'], // Chain 1: undefined, Chain 137: EOA
+        counterfactualResponses: ['0x', '0x'],
+      });
 
       mockGetBalance.mockResolvedValue(BigInt(0));
 
@@ -149,7 +218,10 @@ describe('useWalletModeVerification', () => {
 
   describe('EOA Address Resolution', () => {
     it('should use eoaAddress prop when provided', async () => {
-      mockGetCode.mockResolvedValue('0x');
+      setupMockGetCode({
+        eoaResponses: ['0x', '0x'],
+        counterfactualResponses: ['0x', '0x'],
+      });
       mockGetBalance.mockResolvedValue(BigInt(0));
 
       const { result } = renderHook(() =>
@@ -163,12 +235,16 @@ describe('useWalletModeVerification', () => {
         expect(result.current.walletMode).toBeDefined();
       });
 
-      const firstCall = mockGetCode.mock.calls[0];
-      expect(firstCall[0].address).toBe(TEST_EOA_ADDRESS);
+      expect(mockGetCode).toHaveBeenCalledWith({
+        address: TEST_EOA_ADDRESS,
+      });
     });
 
     it('should derive EOA from privateKey when eoaAddress not provided', async () => {
-      mockGetCode.mockResolvedValue('0x');
+      setupMockGetCode({
+        eoaResponses: ['0x', '0x'],
+        counterfactualResponses: ['0x', '0x'],
+      });
       mockGetBalance.mockResolvedValue(BigInt(0));
 
       const { result } = renderHook(() =>
@@ -183,13 +259,17 @@ describe('useWalletModeVerification', () => {
       });
 
       expect(privateKeyToAccount).toHaveBeenCalledWith(TEST_PRIVATE_KEY);
-      const firstCall = mockGetCode.mock.calls[0];
-      expect(firstCall[0].address).toBe(TEST_EOA_ADDRESS);
+      expect(mockGetCode).toHaveBeenCalledWith({
+        address: TEST_EOA_ADDRESS,
+      });
     });
 
     it('should prioritize eoaAddress over privateKey', async () => {
       const customEoaAddress = '0x9999999999999999999999999999999999999999';
-      mockGetCode.mockResolvedValue('0x');
+      setupMockGetCode({
+        eoaResponses: ['0x', '0x'],
+        counterfactualResponses: ['0x', '0x'],
+      });
       mockGetBalance.mockResolvedValue(BigInt(0));
 
       const { result } = renderHook(() =>
@@ -204,11 +284,12 @@ describe('useWalletModeVerification', () => {
         expect(result.current.walletMode).toBeDefined();
       });
 
-      const firstCall = mockGetCode.mock.calls[0];
-      expect(firstCall[0].address).toBe(customEoaAddress);
+      expect(mockGetCode).toHaveBeenCalledWith({
+        address: customEoaAddress,
+      });
     });
 
-    it('should set error when no EOA address is available', async () => {
+    it('should return early when no EOA address is available', async () => {
       const { result } = renderHook(() =>
         useWalletModeVerification({
           kit: mockKit,
@@ -218,6 +299,8 @@ describe('useWalletModeVerification', () => {
       await waitFor(() => {
         expect(result.current.walletMode).toBe('modular');
         expect(result.current.eip7702Info).toEqual({});
+        // When both privateKey and eoaAddress are missing, hook returns early without error
+        expect(result.current.error).toBeNull();
       });
 
       expect(mockGetCode).not.toHaveBeenCalled();
@@ -225,11 +308,11 @@ describe('useWalletModeVerification', () => {
   });
 
   describe('Smart Account Deployment Checks', () => {
-    it('should remain modular when smart account is deployed', async () => {
-      mockGetCode
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x1234')
-        .mockResolvedValue('0x');
+    it('should remain modular when smart account is deployed on any chain', async () => {
+      setupMockGetCode({
+        eoaResponses: ['0x', '0x'],
+        counterfactualResponses: ['0x1234', '0x'], // Chain 1: deployed, Chain 137: not deployed
+      });
 
       mockGetBalance.mockResolvedValue(BigInt(0));
 
@@ -244,14 +327,20 @@ describe('useWalletModeVerification', () => {
         expect(result.current.walletMode).toBe('modular');
         expect(result.current.eip7702Info).toEqual({});
       });
+
+      expect(mockGetCode).toHaveBeenCalledTimes(4);
+      expect(mockGetBalance).toHaveBeenCalledTimes(1); // Only chain 137 checks balance
     });
 
-    it('should remain modular when smart account has balance', async () => {
-      mockGetCode.mockResolvedValueOnce('0x').mockResolvedValue('0x');
+    it('should remain modular when smart account has balance on any chain', async () => {
+      setupMockGetCode({
+        eoaResponses: ['0x', '0x'],
+        counterfactualResponses: ['0x', '0x'], // Not deployed on either chain
+      });
 
       mockGetBalance
-        .mockResolvedValueOnce(BigInt(1000000000000000000))
-        .mockResolvedValue(BigInt(0));
+        .mockResolvedValueOnce(BigInt(1000000000000000000)) // Chain 1: has balance
+        .mockResolvedValueOnce(BigInt(0)); // Chain 137: no balance
 
       const { result } = renderHook(() =>
         useWalletModeVerification({
@@ -265,16 +354,37 @@ describe('useWalletModeVerification', () => {
         expect(result.current.eip7702Info).toEqual({});
       });
     });
+
+    it('should check deployment across all chains', async () => {
+      setupMockGetCode({
+        eoaResponses: ['0x', '0x'],
+        counterfactualResponses: ['0x', '0x'], // Not deployed on either chain
+      });
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('delegatedEoa');
+      });
+
+      expect(mockGetCode).toHaveBeenCalledTimes(4);
+      expect(mockGetBalance).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('EIP-7702 Detection', () => {
-    it('should detect EIP-7702 implementation on EOA', async () => {
-      mockGetCode
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce(TEST_EIP7702_CODE)
-        .mockResolvedValue('0x');
+    it('should detect our EIP-7702 implementation on EOA', async () => {
+      setupMockGetCode({
+        eoaResponses: [TEST_EIP7702_CODE, '0x'], // Chain 1: our EIP-7702, Chain 137: no EIP-7702
+        counterfactualResponses: ['0x', '0x'],
+      });
 
       mockGetBalance.mockResolvedValue(BigInt(0));
 
@@ -302,12 +412,10 @@ describe('useWalletModeVerification', () => {
       const otherImplementation = '0x2222222222222222222222222222222222222222';
       const otherEip7702Code = `0xef0100${otherImplementation.slice(2)}`;
 
-      mockGetCode
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce(otherEip7702Code)
-        .mockResolvedValue('0x');
+      setupMockGetCode({
+        eoaResponses: [otherEip7702Code, '0x'], // Chain 1: other EIP-7702, Chain 137: no EIP-7702
+        counterfactualResponses: ['0x', '0x'],
+      });
 
       mockGetBalance.mockResolvedValue(BigInt(0));
 
@@ -330,11 +438,10 @@ describe('useWalletModeVerification', () => {
     });
 
     it('should handle no EIP-7702 implementation', async () => {
-      mockGetCode
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValue('0x');
+      setupMockGetCode({
+        eoaResponses: ['0x', '0x'], // No EIP-7702 on either chain
+        counterfactualResponses: ['0x', '0x'],
+      });
 
       mockGetBalance.mockResolvedValue(BigInt(0));
 
@@ -353,64 +460,21 @@ describe('useWalletModeVerification', () => {
           isOtherImplementation: false,
           delegateAddress: null,
         });
+        expect(result.current.eip7702Info[137]).toEqual({
+          hasImplementation: false,
+          isOurImplementation: false,
+          isOtherImplementation: false,
+          delegateAddress: null,
+        });
       });
     });
-  });
 
-  describe('Smart Contract Detection - Additional Cases', () => {
-    it('should detect smart contract when privateKey derives contract address', async () => {
-      const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
-
-      const contractAddress = '0xContractFromPrivateKey';
-      (privateKeyToAccount as any).mockReturnValue({
-        address: contractAddress,
+    it('should check EIP-7702 across all chains', async () => {
+      setupMockGetCode({
+        eoaResponses: [TEST_EIP7702_CODE, '0x'], // Chain 1: EIP-7702, Chain 137: no EIP-7702
+        counterfactualResponses: ['0x', '0x'],
       });
 
-      mockGetCode
-        .mockResolvedValueOnce(TEST_OTHER_CONTRACT_CODE)
-        .mockResolvedValue('0x');
-
-      const { result } = renderHook(() =>
-        useWalletModeVerification({
-          privateKey: TEST_PRIVATE_KEY,
-          kit: mockKit,
-        })
-      );
-
-      await waitFor(() => {
-        expect(result.current.walletMode).toBe('modular');
-        expect(result.current.eip7702Info).toEqual({});
-      });
-
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('is a smart contract, not an EOA')
-      );
-      expect(mockKit.getWalletAddress).not.toHaveBeenCalled();
-
-      consoleWarnSpy.mockRestore();
-    });
-
-    it('should NOT call getWalletAddress when contract is detected', async () => {
-      mockGetCode.mockResolvedValueOnce(TEST_OTHER_CONTRACT_CODE);
-
-      renderHook(() =>
-        useWalletModeVerification({
-          eoaAddress: TEST_SMART_CONTRACT_ADDRESS,
-          kit: mockKit,
-        })
-      );
-
-      await waitFor(() => {
-        expect(mockGetCode).toHaveBeenCalled();
-      });
-
-      expect(mockKit.getWalletAddress).not.toHaveBeenCalled();
-    });
-
-    it('should handle getCode returning undefined', async () => {
-      mockGetCode.mockResolvedValueOnce(undefined).mockResolvedValue('0x');
       mockGetBalance.mockResolvedValue(BigInt(0));
 
       const { result } = renderHook(() =>
@@ -421,42 +485,70 @@ describe('useWalletModeVerification', () => {
       );
 
       await waitFor(() => {
-        expect(result.current.walletMode).toBeDefined();
+        expect(result.current.eip7702Info[1]).toBeDefined();
+        expect(result.current.eip7702Info[137]).toBeDefined();
       });
 
-      expect(result.current.walletMode).toBe('delegatedEoa');
+      expect(result.current.eip7702Info[1].hasImplementation).toBe(true);
+      expect(result.current.eip7702Info[137].hasImplementation).toBe(false);
     });
 
-    it('should handle both privateKey and eoaAddress where eoaAddress is contract', async () => {
-      const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
+    it('should handle malformed EIP-7702 code', async () => {
+      const malformedCode = '0xef0100'; // Missing delegate address
 
-      mockGetCode.mockResolvedValueOnce(TEST_OTHER_CONTRACT_CODE);
+      setupMockGetCode({
+        eoaResponses: [malformedCode, '0x'], // Chain 1: malformed EIP-7702, Chain 137: no EIP-7702
+        counterfactualResponses: ['0x', '0x'],
+      });
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
 
       const { result } = renderHook(() =>
         useWalletModeVerification({
-          privateKey: TEST_PRIVATE_KEY,
-          eoaAddress: TEST_SMART_CONTRACT_ADDRESS,
+          eoaAddress: TEST_EOA_ADDRESS,
           kit: mockKit,
         })
       );
 
       await waitFor(() => {
-        expect(result.current.walletMode).toBe('modular');
+        expect(result.current.walletMode).toBe('delegatedEoa');
       });
 
-      const firstCall = mockGetCode.mock.calls[0];
-      expect(firstCall[0].address).toBe(TEST_SMART_CONTRACT_ADDRESS);
-      expect(mockKit.getWalletAddress).not.toHaveBeenCalled();
+      expect(result.current.eip7702Info[1].delegateAddress).toBeNull();
+    });
 
-      consoleWarnSpy.mockRestore();
+    it('should extract delegate address correctly from EIP-7702 code', async () => {
+      const customDelegate = '0x3333333333333333333333333333333333333333';
+      const eip7702Code = `0xef0100${customDelegate.slice(2)}`;
+
+      setupMockGetCode({
+        eoaResponses: [eip7702Code, '0x'], // Chain 1: EIP-7702 with custom delegate, Chain 137: no EIP-7702
+        counterfactualResponses: ['0x', '0x'],
+      });
+
+      mockGetBalance.mockResolvedValue(BigInt(0));
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          eoaAddress: TEST_EOA_ADDRESS,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.eip7702Info[1].delegateAddress).toBe(
+          customDelegate.toLowerCase()
+        );
+      });
     });
   });
 
   describe('Loading State', () => {
     it('should set isLoading to true initially', async () => {
-      mockGetCode.mockResolvedValue('0x');
+      setupMockGetCode({
+        eoaResponses: ['0x', '0x'],
+        counterfactualResponses: ['0x', '0x'],
+      });
       mockGetBalance.mockResolvedValue(BigInt(0));
 
       const { result } = renderHook(() =>
@@ -474,7 +566,9 @@ describe('useWalletModeVerification', () => {
     });
 
     it('should set isLoading to false after contract detection', async () => {
-      mockGetCode.mockResolvedValueOnce(TEST_OTHER_CONTRACT_CODE);
+      setupMockGetCode({
+        eoaResponses: [TEST_OTHER_CONTRACT_CODE, '0x'],
+      });
 
       const { result } = renderHook(() =>
         useWalletModeVerification({
@@ -489,87 +583,11 @@ describe('useWalletModeVerification', () => {
     });
   });
 
-  describe('Multiple Chains', () => {
-    it('should check deployment across all visible chains', async () => {
-      mockGetCode
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x1234')
-        .mockResolvedValue('0x');
-
-      mockGetBalance.mockResolvedValue(BigInt(0));
-
-      const { result } = renderHook(() =>
-        useWalletModeVerification({
-          eoaAddress: TEST_EOA_ADDRESS,
-          kit: mockKit,
-        })
-      );
-
-      await waitFor(() => {
-        expect(result.current.walletMode).toBe('modular');
-      });
-
-      expect(mockGetCode).toHaveBeenCalledTimes(3);
-      expect(mockGetBalance).toHaveBeenCalled();
-    });
-
-    it('should check EIP-7702 across all chains', async () => {
-      mockGetCode
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce(TEST_EIP7702_CODE)
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValue('0x');
-
-      mockGetBalance.mockResolvedValue(BigInt(0));
-
-      const { result } = renderHook(() =>
-        useWalletModeVerification({
-          eoaAddress: TEST_EOA_ADDRESS,
-          kit: mockKit,
-        })
-      );
-
-      await waitFor(() => {
-        expect(result.current.eip7702Info[1]).toBeDefined();
-        expect(result.current.eip7702Info[137]).toBeDefined();
-      });
-
-      expect(result.current.eip7702Info[1].hasImplementation).toBe(true);
-    });
-
-    it('should handle EIP-7702 on one chain but not others', async () => {
-      mockGetCode
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce(TEST_EIP7702_CODE)
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValue('0x');
-
-      mockGetBalance.mockResolvedValue(BigInt(0));
-
-      const { result } = renderHook(() =>
-        useWalletModeVerification({
-          eoaAddress: TEST_EOA_ADDRESS,
-          kit: mockKit,
-        })
-      );
-
-      await waitFor(() => {
-        expect(result.current.walletMode).toBe('delegatedEoa');
-      });
-
-      expect(result.current.eip7702Info[1].hasImplementation).toBe(true);
-      expect(result.current.eip7702Info[137].hasImplementation).toBe(false);
-    });
-  });
-
   describe('Error Handling', () => {
     it('should handle getWalletAddress() error after validation', async () => {
-      mockGetCode.mockResolvedValueOnce('0x').mockResolvedValue('0x');
+      setupMockGetCode({
+        eoaResponses: ['0x', '0x'],
+      });
       mockGetBalance.mockResolvedValue(BigInt(0));
       (mockKit.getWalletAddress as any).mockRejectedValueOnce(
         new Error('getWalletAddress failed')
@@ -589,12 +607,21 @@ describe('useWalletModeVerification', () => {
     });
 
     it('should handle error in deployment checks', async () => {
-      mockGetCode
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockRejectedValueOnce(new Error('Network error'))
-        .mockResolvedValue('0x');
-
+      // Setup EOA checks to succeed, but counterfactual check to fail
+      let callCount = 0;
+      mockGetCode.mockImplementation(() => {
+        callCount++;
+        if (callCount <= 2) {
+          // EOA checks succeed
+          return Promise.resolve('0x');
+        }
+        if (callCount === 3) {
+          // First counterfactual check fails
+          return Promise.reject(new Error('Network error'));
+        }
+        // Remaining calls succeed
+        return Promise.resolve('0x');
+      });
       mockGetBalance.mockResolvedValue(BigInt(0));
 
       const { result } = renderHook(() =>
@@ -610,15 +637,9 @@ describe('useWalletModeVerification', () => {
       });
     });
 
-    it('should handle error in EIP-7702 checks', async () => {
-      mockGetCode
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockRejectedValueOnce(new Error('Network error'))
-        .mockResolvedValue('0x');
-
-      mockGetBalance.mockResolvedValue(BigInt(0));
+    it('should handle error in EOA address checks', async () => {
+      // Don't use setupMockGetCode here - we want to test error handling
+      mockGetCode.mockRejectedValueOnce(new Error('Network error'));
 
       const { result } = renderHook(() =>
         useWalletModeVerification({
@@ -650,61 +671,6 @@ describe('useWalletModeVerification', () => {
     });
   });
 
-  describe('EIP-7702 Code Parsing', () => {
-    it('should handle malformed EIP-7702 code', async () => {
-      const malformedCode = '0xef0100'; // Missing delegate address
-
-      mockGetCode
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce(malformedCode)
-        .mockResolvedValue('0x');
-
-      mockGetBalance.mockResolvedValue(BigInt(0));
-
-      const { result } = renderHook(() =>
-        useWalletModeVerification({
-          eoaAddress: TEST_EOA_ADDRESS,
-          kit: mockKit,
-        })
-      );
-
-      await waitFor(() => {
-        expect(result.current.walletMode).toBe('delegatedEoa');
-      });
-
-      expect(result.current.eip7702Info[1].delegateAddress).toBeNull();
-    });
-
-    it('should extract delegate address correctly from EIP-7702 code', async () => {
-      const customDelegate = '0x3333333333333333333333333333333333333333';
-      const eip7702Code = `0xef0100${customDelegate.slice(2)}`;
-
-      mockGetCode
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce('0x')
-        .mockResolvedValueOnce(eip7702Code)
-        .mockResolvedValue('0x');
-
-      mockGetBalance.mockResolvedValue(BigInt(0));
-
-      const { result } = renderHook(() =>
-        useWalletModeVerification({
-          eoaAddress: TEST_EOA_ADDRESS,
-          kit: mockKit,
-        })
-      );
-
-      await waitFor(() => {
-        expect(result.current.eip7702Info[1].delegateAddress).toBe(
-          customDelegate.toLowerCase()
-        );
-      });
-    });
-  });
-
   describe('Edge Cases', () => {
     it('should handle missing kit', async () => {
       const { result } = renderHook(() =>
@@ -720,29 +686,23 @@ describe('useWalletModeVerification', () => {
       });
     });
 
-    it('should handle errors gracefully', async () => {
-      const error = new Error('Network error');
-      mockGetCode.mockRejectedValueOnce(error);
-
+    it('should handle missing both privateKey and eoaAddress', async () => {
       const { result } = renderHook(() =>
         useWalletModeVerification({
-          eoaAddress: TEST_EOA_ADDRESS,
           kit: mockKit,
         })
       );
 
       await waitFor(() => {
-        expect(result.current.error).toBeTruthy();
         expect(result.current.walletMode).toBe('modular');
+        expect(result.current.eip7702Info).toEqual({});
       });
     });
 
-    it('should check mainnet first for smart contract detection', async () => {
-      mockGetCode
-        .mockResolvedValueOnce(TEST_OTHER_CONTRACT_CODE)
-        .mockResolvedValue('0x');
-
-      mockGetBalance.mockResolvedValue(BigInt(0));
+    it('should check all chains for smart contract detection', async () => {
+      setupMockGetCode({
+        eoaResponses: [TEST_OTHER_CONTRACT_CODE, '0x'], // Contract on chain 1
+      });
 
       renderHook(() =>
         useWalletModeVerification({
@@ -755,32 +715,69 @@ describe('useWalletModeVerification', () => {
         expect(mockGetCode).toHaveBeenCalled();
       });
 
-      const firstCall = mockGetCode.mock.calls[0];
-      expect(firstCall[0].address).toBe(TEST_SMART_CONTRACT_ADDRESS);
+      expect(mockGetCode).toHaveBeenCalledTimes(2);
+      expect(mockKit.getWalletAddress).not.toHaveBeenCalled();
     });
 
-    it('should handle chain fallback when mainnet not available', async () => {
-      vi.doMock('../../utils/blockchain', () => ({
-        visibleChains: [{ id: 137, name: 'Polygon', testnet: false }],
-      }));
+    it('should NOT call getWalletAddress when contract is detected', async () => {
+      setupMockGetCode({
+        eoaResponses: [TEST_OTHER_CONTRACT_CODE, '0x'],
+      });
 
-      mockGetCode.mockResolvedValueOnce('0x').mockResolvedValue('0x');
-      mockGetBalance.mockResolvedValue(BigInt(0));
-
-      const { result } = renderHook(() =>
+      renderHook(() =>
         useWalletModeVerification({
-          eoaAddress: TEST_EOA_ADDRESS,
+          eoaAddress: TEST_SMART_CONTRACT_ADDRESS,
           kit: mockKit,
         })
       );
 
       await waitFor(() => {
-        expect(result.current.walletMode).toBeDefined();
+        expect(mockGetCode).toHaveBeenCalled();
       });
+
+      expect(mockKit.getWalletAddress).not.toHaveBeenCalled();
+    });
+
+    it('should handle contract detection when privateKey derives contract address', async () => {
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      const contractAddress = '0xContractFromPrivateKey';
+      (privateKeyToAccount as any).mockReturnValue({
+        address: contractAddress,
+      });
+
+      setupMockGetCode({
+        eoaResponses: [TEST_OTHER_CONTRACT_CODE, '0x'], // Contract on chain 1
+      });
+
+      const { result } = renderHook(() =>
+        useWalletModeVerification({
+          privateKey: TEST_PRIVATE_KEY,
+          kit: mockKit,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.walletMode).toBe('modular');
+        expect(result.current.eip7702Info).toEqual({});
+      });
+
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      const warningMessage = consoleWarnSpy.mock.calls[0][0] as string;
+      expect(warningMessage).toContain('is a smart contract');
+      expect(warningMessage).toContain('not an EOA');
+      expect(mockKit.getWalletAddress).not.toHaveBeenCalled();
+
+      consoleWarnSpy.mockRestore();
     });
 
     it('should clear error on successful verification', async () => {
-      mockGetCode.mockResolvedValue('0x');
+      setupMockGetCode({
+        eoaResponses: ['0x', '0x'],
+        counterfactualResponses: ['0x', '0x'],
+      });
       mockGetBalance.mockResolvedValue(BigInt(0));
 
       const { result } = renderHook(

--- a/src/hooks/useWalletModeVerification.tsx
+++ b/src/hooks/useWalletModeVerification.tsx
@@ -80,29 +80,44 @@ export const useWalletModeVerification = ({
 
         if (cancelled) return;
 
+        // Get code for resolvedAddress across all chains (reused for both validation and EIP-7702 checks)
+        const eoaAddressCodeChecks = await Promise.all(
+          visibleChains.map(async (chain) => {
+            const publicClient = createPublicClient({
+              chain,
+              transport: http(),
+            });
+
+            const code = await publicClient.getCode({
+              address: resolvedAddress as `0x${string}`,
+            });
+
+            return {
+              chainId: chain.id,
+              code,
+              isSmartContract:
+                code !== undefined &&
+                code !== '0x' &&
+                !code.startsWith('0xef0100'),
+            };
+          })
+        );
+
         // Validate that resolvedAddress is actually an EOA, not a smart contract
-        // Check on mainnet first (chainId 1) as a quick validation
-        const mainnetClient = createPublicClient({
-          chain:
-            visibleChains.find((chain) => chain.id === 1) || visibleChains[0],
-          transport: http(),
-        });
-
-        const addressCodeCheck = await mainnetClient.getCode({
-          address: resolvedAddress as `0x${string}`,
-        });
-
-        // If the address has code that's not EIP-7702 format, it's a smart contract
-        const isSmartContract =
-          addressCodeCheck !== undefined &&
-          addressCodeCheck !== '0x' &&
-          !addressCodeCheck.startsWith('0xef0100');
+        // If the address is a smart contract (not EIP-7702) on any chain, treat it as a contract
+        const isSmartContract = eoaAddressCodeChecks.some(
+          (check) => check.isSmartContract
+        );
 
         if (isSmartContract) {
           // The provided address (from eoaAddress prop or privateKey) is a smart contract, not an EOA
           // EIP-7702 is only applicable to EOAs, so skip the check and default to modular
+          const contractChains = eoaAddressCodeChecks
+            .filter((check) => check.isSmartContract)
+            .map((check) => check.chainId)
+            .join(', ');
           console.warn(
-            `Address ${resolvedAddress} is a smart contract, not an EOA. Skipping EIP-7702 check and getWalletAddress() call.`
+            `Address ${resolvedAddress} is a smart contract on chain(s): ${contractChains}, not an EOA. Skipping EIP-7702 check and getWalletAddress() call.`
           );
           if (cancelled) return;
           setEip7702Info({});
@@ -113,9 +128,6 @@ export const useWalletModeVerification = ({
         // At this point, resolvedAddress is confirmed to be an EOA (or has EIP-7702 designation)
         // Get counterfactual address from kit (in modular mode)
         const counterfactualAddress = await kit.getWalletAddress();
-
-        // We can safely refer to resolvedAddress as the EOA address for the rest of the function
-        const resolvedEoaAddress = resolvedAddress;
 
         // Check all supported chains
         let shouldRemainModular = false;
@@ -167,46 +179,37 @@ export const useWalletModeVerification = ({
 
         // If we reach here, smart account is not deployed and has no assets
         // Check for EIP-7702 implementation on EOA
-        const eip7702Checks = await Promise.all(
-          visibleChains.map(async (chain) => {
-            const publicClient = createPublicClient({
-              chain,
-              transport: http(),
-            });
+        const eip7702Checks = eoaAddressCodeChecks.map((check) => {
+          const senderCode = check.code;
 
-            const senderCode = await publicClient.getCode({
-              address: resolvedEoaAddress as `0x${string}`,
-            });
+          const hasEIP7702Designation =
+            senderCode !== undefined &&
+            senderCode !== '0x' &&
+            senderCode.startsWith('0xef0100');
 
-            const hasEIP7702Designation =
-              senderCode !== undefined &&
-              senderCode !== '0x' &&
-              senderCode.startsWith('0xef0100');
+          // Extract delegate address from EIP-7702 code if present
+          let delegateAddress: string | null = null;
+          let isOurImplementation = false;
 
-            // Extract delegate address from EIP-7702 code if present
-            let delegateAddress: string | null = null;
-            let isOurImplementation = false;
+          if (hasEIP7702Designation) {
+            // EIP-7702 format: 0xef0100 + XX-byte delegate address
+            // Extract delegate address using regex
+            const match = senderCode.match(/^0xef0100(.{40})$/);
+            delegateAddress = match ? `0x${match[1]}` : null;
 
-            if (hasEIP7702Designation) {
-              // EIP-7702 format: 0xef0100 + XX-byte delegate address
-              // Extract delegate address using regex
-              const match = senderCode.match(/^0xef0100(.{40})$/);
-              delegateAddress = match ? `0x${match[1]}` : null;
+            // Check if it's our implementation (Kernel V3)
+            isOurImplementation =
+              delegateAddress?.toLowerCase() ===
+              OUR_EIP7702_IMPLEMENTATION_ADDRESS.toLowerCase();
+          }
 
-              // Check if it's our implementation (Kernel V3)
-              isOurImplementation =
-                delegateAddress?.toLowerCase() ===
-                OUR_EIP7702_IMPLEMENTATION_ADDRESS.toLowerCase();
-            }
-
-            return {
-              hasEIP7702: hasEIP7702Designation,
-              chainId: chain.id,
-              delegateAddress,
-              isOurImplementation,
-            };
-          })
-        );
+          return {
+            hasEIP7702: hasEIP7702Designation,
+            chainId: check.chainId,
+            delegateAddress,
+            isOurImplementation,
+          };
+        });
         if (cancelled) return;
 
         // Build per-chain implementation details

--- a/src/hooks/useWalletModeVerification.tsx
+++ b/src/hooks/useWalletModeVerification.tsx
@@ -59,21 +59,63 @@ export const useWalletModeVerification = ({
       setError(null);
 
       try {
-        // Get EOA address from privateKey
-        let resolvedEoaAddress: string;
+        // Resolve the address to check (could be from privateKey or eoaAddress prop)
+        let resolvedAddress: string | undefined;
         if (privateKey) {
           const eoaAccount = privateKeyToAccount(privateKey as `0x${string}`);
-          resolvedEoaAddress = eoaAccount.address;
+          resolvedAddress = eoaAccount.address;
         }
 
-        // Get counterfactual address from kit (in modular mode)
-        const counterfactualAddress = await kit.getWalletAddress();
-
         if (eoaAddress) {
-          resolvedEoaAddress = eoaAddress;
+          resolvedAddress = eoaAddress;
+        }
+
+        if (!resolvedAddress) {
+          if (cancelled) return;
+          setEip7702Info({});
+          setWalletMode('modular');
+          setError('No address available');
+          return;
         }
 
         if (cancelled) return;
+
+        // Validate that resolvedAddress is actually an EOA, not a smart contract
+        // Check on mainnet first (chainId 1) as a quick validation
+        const mainnetClient = createPublicClient({
+          chain:
+            visibleChains.find((chain) => chain.id === 1) || visibleChains[0],
+          transport: http(),
+        });
+
+        const addressCodeCheck = await mainnetClient.getCode({
+          address: resolvedAddress as `0x${string}`,
+        });
+
+        // If the address has code that's not EIP-7702 format, it's a smart contract
+        const isSmartContract =
+          addressCodeCheck !== undefined &&
+          addressCodeCheck !== '0x' &&
+          !addressCodeCheck.startsWith('0xef0100');
+
+        if (isSmartContract) {
+          // The provided address (from eoaAddress prop or privateKey) is a smart contract, not an EOA
+          // EIP-7702 is only applicable to EOAs, so skip the check and default to modular
+          console.warn(
+            `Address ${resolvedAddress} is a smart contract, not an EOA. Skipping EIP-7702 check and getWalletAddress() call.`
+          );
+          if (cancelled) return;
+          setEip7702Info({});
+          setWalletMode('modular');
+          return;
+        }
+
+        // At this point, resolvedAddress is confirmed to be an EOA (or has EIP-7702 designation)
+        // Get counterfactual address from kit (in modular mode)
+        const counterfactualAddress = await kit.getWalletAddress();
+
+        // We can safely refer to resolvedAddress as the EOA address for the rest of the function
+        const resolvedEoaAddress = resolvedAddress;
 
         // Check all supported chains
         let shouldRemainModular = false;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Fix to check if provided eoa address is actually a smart account or not

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit Tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet/address validation across multiple blockchains, better detection of smart-contract vs EOA wallets, and more robust fallback/error handling.
  * Correctly switches to modular flow for contract wallets and avoids persisting spurious errors.

* **Tests**
  * Added comprehensive test coverage for wallet verification, cross-chain scenarios, EIP-7702 cases, and numerous edge/error conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->