### PR TITLE
BNB Fix on Pulse

### DIFF
--- a/src/apps/pulse/components/Buy/tests/Buy.test.tsx
+++ b/src/apps/pulse/components/Buy/tests/Buy.test.tsx
@@ -94,6 +94,11 @@ vi.mock('../../../../../services/pillarXApiTransactionsHistory', () => ({
 
 vi.mock('../../hooks/useRelayBuy', () => ({
   default: vi.fn(() => ({
+    getUSDCToken: vi.fn(() => ({
+      chainId: 1,
+      address: '0xUSDC1234567890',
+      decimals: 6,
+    })),
     getBestOffer: vi.fn(),
     isInitialized: false,
     error: null,

--- a/src/apps/pulse/components/Sell/PreviewSell.tsx
+++ b/src/apps/pulse/components/Sell/PreviewSell.tsx
@@ -69,7 +69,7 @@ const PreviewSell = (props: PreviewSellProps) => {
   const [isTransactionSuccess, setIsTransactionSuccess] = useState(false);
   const previewModalRef = useRef<HTMLDivElement>(null);
   const {
-    getUSDCAddress,
+    getUSDCToken,
     executeSell,
     error,
     clearError,
@@ -232,7 +232,8 @@ const PreviewSell = (props: PreviewSellProps) => {
   //   }
   // };
 
-  const usdcAddress = getUSDCAddress(selectedChainIdForSettlement || 0);
+  const usdcToken = getUSDCToken(selectedChainIdForSettlement || 0);
+  const usdcAddress = usdcToken ? usdcToken.address : '';
 
   // Clean up pulse-sell batch when component unmounts or preview closes
   useEffect(() => {

--- a/src/apps/pulse/components/Sell/tests/PreviewSell.test.tsx
+++ b/src/apps/pulse/components/Sell/tests/PreviewSell.test.tsx
@@ -162,7 +162,11 @@ describe('<PreviewSell />', () => {
     vi.clearAllMocks();
 
     (useRelaySell as any).mockReturnValue({
-      getUSDCAddress: vi.fn(() => '0xUSDC1234567890'),
+      getUSDCToken: vi.fn(() => ({
+        chainId: 1,
+        address: '0xUSDC1234567890',
+        decimals: 6,
+      })),
       executeSell: vi.fn(),
       error: null,
       clearError: vi.fn(),
@@ -259,7 +263,11 @@ describe('<PreviewSell />', () => {
           })
       );
       (useRelaySell as any).mockReturnValue({
-        getUSDCAddress: vi.fn(() => '0xUSDC1234567890'),
+        getUSDCToken: vi.fn(() => ({
+          chainId: 1,
+          address: '0xUSDC1234567890',
+          decimals: 6,
+        })),
         executeSell: mockExecuteSell,
         error: null,
         clearError: vi.fn(),
@@ -299,7 +307,11 @@ describe('<PreviewSell />', () => {
   describe('handles error states', () => {
     it('displays relay error', () => {
       (useRelaySell as any).mockReturnValue({
-        getUSDCAddress: vi.fn(() => '0xUSDC1234567890'),
+        getUSDCToken: vi.fn(() => ({
+          chainId: 1,
+          address: '0xUSDC1234567890',
+          decimals: 6,
+        })),
         executeSell: vi.fn(),
         error: 'Relay error occurred',
         clearError: vi.fn(),
@@ -334,7 +346,7 @@ describe('<PreviewSell />', () => {
   describe('handles edge cases', () => {
     it('handles missing USDC address', () => {
       (useRelaySell as any).mockReturnValue({
-        getUSDCAddress: vi.fn(() => null),
+        getUSDCToken: vi.fn(() => null),
         executeSell: vi.fn(),
         error: null,
         clearError: vi.fn(),

--- a/src/apps/pulse/constants/tokens.ts
+++ b/src/apps/pulse/constants/tokens.ts
@@ -1,13 +1,41 @@
 import { isGnosisEnabled } from '../../../utils/blockchain';
 
 export const allStableCurrencies = [
-  { chainId: 1, address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' },
-  { chainId: 10, address: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85' }, // USDC on Optimism
-  { chainId: 137, address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359' }, // USDC on Polygon
-  { chainId: 8453, address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' }, // USDC on Base
-  { chainId: 42161, address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' }, // USDC on Arbitrum
-  { chainId: 56, address: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d' }, // USDC on BNB Smart Chain
-  { chainId: 100, address: '0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0' }, // USDC on Gnosis
+  {
+    chainId: 1,
+    address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    decimals: 6,
+  },
+  {
+    chainId: 10,
+    address: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
+    decimals: 6,
+  }, // USDC on Optimism
+  {
+    chainId: 137,
+    address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+    decimals: 6,
+  }, // USDC on Polygon
+  {
+    chainId: 8453,
+    address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    decimals: 6,
+  }, // USDC on Base
+  {
+    chainId: 42161,
+    address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+    decimals: 6,
+  }, // USDC on Arbitrum
+  {
+    chainId: 56,
+    address: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
+    decimals: 18,
+  }, // USDC on BNB Smart Chain
+  {
+    chainId: 100,
+    address: '0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0',
+    decimals: 6,
+  }, // USDC on Gnosis
 ];
 
 export const STABLE_CURRENCIES = allStableCurrencies.filter(

--- a/src/apps/pulse/hooks/tests/useRelaySell.test.tsx
+++ b/src/apps/pulse/hooks/tests/useRelaySell.test.tsx
@@ -53,7 +53,7 @@ vi.mock('../../constants/tokens', () => ({
     {
       chainId: 1,
       address: '0xA0b86a33E6441b8C4C8C0C8C0C8C0C8C0C8C0C8C',
-      symbol: 'USDC',
+      decimals: 6,
     },
   ],
 }));
@@ -182,7 +182,7 @@ describe('useRelaySell', () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBe(null);
     expect(result.current.isInitialized).toBe(false);
-    expect(typeof result.current.getUSDCAddress).toBe('function');
+    expect(typeof result.current.getUSDCToken).toBe('function');
     expect(typeof result.current.getBestSellOffer).toBe('function');
     expect(typeof result.current.executeSell).toBe('function');
     expect(typeof result.current.buildSellTransactions).toBe('function');
@@ -249,7 +249,7 @@ describe('useRelaySell', () => {
     expect(result.current.isInitialized).toBe(true);
   });
 
-  it('getUSDCAddress returns correct address for supported chain', async () => {
+  it('getUSDCToken returns correct token for supported chain', async () => {
     const useRelaySdk = await import('../useRelaySdk');
     const useTransactionKit = await import(
       '../../../../hooks/useTransactionKit'
@@ -289,11 +289,15 @@ describe('useRelaySell', () => {
 
     const { result } = renderHook(() => useRelaySell());
 
-    const usdcAddress = result.current.getUSDCAddress(1);
-    expect(usdcAddress).toBe('0xA0b86a33E6441b8C4C8C0C8C0C8C0C8C0C8C0C8C');
+    const usdcToken = result.current.getUSDCToken(1);
+    expect(usdcToken?.address).toBe(
+      '0xA0b86a33E6441b8C4C8C0C8C0C8C0C8C0C8C0C8C'
+    );
+    expect(usdcToken?.decimals).toBe(6);
+    expect(usdcToken?.chainId).toBe(1);
   });
 
-  it('getUSDCAddress returns null for unsupported chain', async () => {
+  it('getUSDCToken returns null for unsupported chain', async () => {
     const useRelaySdk = await import('../useRelaySdk');
     const useTransactionKit = await import(
       '../../../../hooks/useTransactionKit'
@@ -333,8 +337,8 @@ describe('useRelaySell', () => {
 
     const { result } = renderHook(() => useRelaySell());
 
-    const usdcAddress = result.current.getUSDCAddress(999);
-    expect(usdcAddress).toBe(null);
+    const usdcToken = result.current.getUSDCToken(999);
+    expect(usdcToken).toBe(null);
   });
 
   it('getBestSellOffer returns null when not initialized', async () => {
@@ -633,7 +637,11 @@ describe('useRelaySell', () => {
 
     const { result } = renderHook(() => useRelaySell());
 
-    const success = await result.current.executeSell(mockSelectedToken, '1.0');
+    const success = await result.current.executeSell(
+      mockSelectedToken,
+      '1.0',
+      1
+    );
 
     expect(success).toBe(false);
 

--- a/src/apps/pulse/hooks/useRelayBuy.ts
+++ b/src/apps/pulse/hooks/useRelayBuy.ts
@@ -108,13 +108,15 @@ export default function useRelayBuy() {
   }, [isInitialized]);
 
   /**
-   * Get the USDC address for a specific chain
+   * Get the USDC token details for a specific chain
    */
-  const getUSDCAddress = (chainId: number): string | null => {
+  const getUSDCToken = (
+    chainId: number
+  ): { chainId: number; address: string; decimals: number } | null => {
     const stableCurrency = STABLE_CURRENCIES.find(
       (currency) => currency.chainId === chainId
     );
-    return stableCurrency?.address || null;
+    return stableCurrency ?? null;
   };
 
   /**
@@ -135,11 +137,14 @@ export default function useRelayBuy() {
         return null;
       }
 
-      const usdcAddress = getUSDCAddress(fromChainId);
-      if (!usdcAddress) {
+      const USDCtoken = getUSDCToken(fromChainId);
+      if (!USDCtoken) {
         setError('Unable to get quote. Please try again.');
         return null;
       }
+
+      const usdcAddress = USDCtoken.address;
+      const usdcDecimals = USDCtoken.decimals;
 
       setIsLoading(true);
       setError(null);
@@ -172,8 +177,11 @@ export default function useRelayBuy() {
           // If USDC price is $0.9998, then $10 USD = 10 / 0.9998 = 10.002 USDC
           const usdcAmount = usdAmount / usdcPrice;
 
-          // Convert to wei using 6 decimals (USDC precision)
-          fromAmountInWei = parseUnits(usdcAmount.toFixed(6), 6);
+          // Convert to wei using USDC decimals (e.g., 6 on Ethereum, 18 on BSC)
+          fromAmountInWei = parseUnits(
+            usdcAmount.toFixed(usdcDecimals),
+            usdcDecimals
+          );
         } catch (parseError) {
           console.error('Failed to parse fromAmount:', parseError);
           setError('Invalid amount. Please try again.');
@@ -308,10 +316,13 @@ export default function useRelayBuy() {
       }
 
       // Get USDC address for the chain
-      const usdcAddress = getUSDCAddress(fromChainId);
-      if (!usdcAddress) {
+      const USDCtoken = getUSDCToken(fromChainId);
+      if (!USDCtoken) {
         throw new Error('USDC address not found for chain');
       }
+
+      const usdcAddress = USDCtoken.address;
+      const usdcDecimals = USDCtoken.decimals;
 
       // Calculate fee distribution: 1% fee, 99% for swap
       // Get the USDC amount needed for the swap from the quote
@@ -357,7 +368,7 @@ export default function useRelayBuy() {
             t.blockchain === `chain-${fromChainId}`
         );
         if (usdcToken && usdcToken.balance) {
-          userUsdcBalance = toWei(usdcToken.balance.toString(), 6); // USDC has 6 decimals
+          userUsdcBalance = toWei(usdcToken.balance.toString(), usdcDecimals);
         }
 
         // Debug: Log balance validation only if there's an issue
@@ -788,7 +799,7 @@ export default function useRelayBuy() {
   );
 
   return {
-    getUSDCAddress,
+    getUSDCToken,
     getBestOffer,
     executeBuy,
     buildTransactions,

--- a/src/apps/pulse/hooks/useRelaySell.ts
+++ b/src/apps/pulse/hooks/useRelaySell.ts
@@ -112,14 +112,19 @@ export default function useRelaySell() {
   }, [isInitialized]);
 
   /**
-   * Get the USDC address for a specific chain
+   * Get the USDC token details for a specific chain
    */
-  const getUSDCAddress = useCallback((chainId: number): string | null => {
-    const stableCurrency = STABLE_CURRENCIES.find(
-      (currency) => currency.chainId === chainId
-    );
-    return stableCurrency?.address || null;
-  }, []);
+  const getUSDCToken = useCallback(
+    (
+      chainId: number
+    ): { chainId: number; address: string; decimals: number } | null => {
+      const stableCurrency = STABLE_CURRENCIES.find(
+        (currency) => currency.chainId === chainId
+      );
+      return stableCurrency ?? null;
+    },
+    []
+  );
 
   /**
    * Get the best sell offer for swapping a token to USDC
@@ -140,11 +145,14 @@ export default function useRelaySell() {
         return null;
       }
 
-      const usdcAddress = getUSDCAddress(toChainId);
-      if (!usdcAddress) {
+      const usdcToken = getUSDCToken(toChainId);
+      if (!usdcToken) {
         setError('Unable to get quote. Please try again.');
         return null;
       }
+
+      const usdcAddress = usdcToken.address;
+      const usdcDecimals = usdcToken.decimals;
 
       setIsLoading(true);
       setError(null);
@@ -205,14 +213,15 @@ export default function useRelaySell() {
           if (currencyOut.amountFormatted) {
             usdcAmount = parseFloat(currencyOut.amountFormatted);
           } else if (currencyOut.amount) {
-            // Convert from raw units to readable format
-            usdcAmount = parseFloat(currencyOut.amount) / 10 ** 6; // USDC has 6 decimals
+            // Convert from raw units to readable format using USDC decimals
+            usdcAmount = parseFloat(currencyOut.amount) / 10 ** usdcDecimals;
           }
 
           // Get the minimum amount (prefer formatted, fallback to raw amount)
           if (currencyOut.minimumAmount) {
-            // minimumAmount is in raw units, convert to readable format
-            minimumAmount = parseFloat(currencyOut.minimumAmount) / 10 ** 6; // USDC has 6 decimals
+            // minimumAmount is in raw units, convert to readable format using USDC decimals
+            minimumAmount =
+              parseFloat(currencyOut.minimumAmount) / 10 ** usdcDecimals;
           } else {
             // Fallback: calculate minimum receive using slippage tolerance
             // Formula: Minimum to receive = Est. to amount × (1 - max.slippage)
@@ -329,11 +338,13 @@ export default function useRelaySell() {
         throw new Error('Fee receiver address is not configured');
       }
 
-      // Get USDC address for the chain
-      const usdcAddress = getUSDCAddress(token.chainId);
-      if (!usdcAddress) {
+      // Get USDC address and decimals for the chain
+      const usdcToken = getUSDCToken(token.chainId);
+      if (!usdcToken) {
         throw new Error('USDC address not found for chain');
       }
+
+      const usdcAddress = usdcToken.address;
 
       // Calculate fee distribution: 99% to user, 1% to fee receiver
       // We swap 100% of the token, then take 1% of the received USDC as fee
@@ -1005,17 +1016,20 @@ export default function useRelaySell() {
         const usdcAfterFee = usdcAfterFirstSwap * 0.99; // 1% fee taken
 
         // Step 3: Get quote for bridging USDC to target chain
-        const usdcAddress = getUSDCAddress(fromChainId);
-        if (!usdcAddress) {
+        const usdcToken = getUSDCToken(fromChainId);
+        if (!usdcToken) {
           setError('Unable to get USDC address for source chain');
           return null;
         }
+
+        const usdcAddress = usdcToken.address;
+        const usdcDecimals = usdcToken.decimals;
 
         const bridgeOffer = await getBestSellOffer({
           fromAmount: usdcAfterFee.toString(),
           fromTokenAddress: usdcAddress,
           fromChainId,
-          fromTokenDecimals: 6,
+          fromTokenDecimals: usdcDecimals,
           toChainId, // Target chain
           slippage,
         });
@@ -1065,7 +1079,7 @@ export default function useRelaySell() {
         setIsLoading(false);
       }
     },
-    [isInitialized, getBestSellOffer, getUSDCAddress]
+    [isInitialized, getBestSellOffer, getUSDCToken]
   );
 
   /**
@@ -1133,11 +1147,14 @@ export default function useRelaySell() {
 
       const fromAmountBigInt = parseUnits(inputAmount, fromToken.decimals);
 
-      // Step 3: Get USDC address
-      const usdcAddress = getUSDCAddress(fromChainId);
-      if (!usdcAddress) {
+      // Step 3: Get USDC address and decimals
+      const usdcToken = getUSDCToken(fromChainId);
+      if (!usdcToken) {
         throw new Error('USDC address not found for source chain');
       }
+
+      const usdcAddress = usdcToken.address;
+      const usdcDecimals = usdcToken.decimals;
 
       // Step 4: Calculate fee for first swap (1% of USDC received)
       const feeReceiver = import.meta.env.VITE_SWAP_FEE_RECEIVER;
@@ -1399,7 +1416,7 @@ export default function useRelaySell() {
       // Step 10: Get quote for USDC bridge
       const usdcToBridgeFormatted = (
         Number(usdcAfterFirstSwapFee) /
-        10 ** 6
+        10 ** usdcDecimals
       ).toString();
 
       let bridgeOffer: SellOffer | null = null;
@@ -1408,7 +1425,7 @@ export default function useRelaySell() {
           fromAmount: usdcToBridgeFormatted,
           fromTokenAddress: usdcAddress,
           fromChainId,
-          fromTokenDecimals: 6,
+          fromTokenDecimals: usdcDecimals,
           toChainId, // Target chain
         });
       } catch (err) {
@@ -1452,7 +1469,10 @@ export default function useRelaySell() {
         }
 
         if (bridgeSpenderAddress) {
-          const usdcAmountBigInt = parseUnits(usdcToBridgeFormatted, 6);
+          const usdcAmountBigInt = parseUnits(
+            usdcToBridgeFormatted,
+            usdcDecimals
+          );
 
           const isAllowance = await isAllowanceSet({
             owner: walletAddress || '',
@@ -1583,7 +1603,7 @@ export default function useRelaySell() {
     },
     [
       getBestSellOffer,
-      getUSDCAddress,
+      getUSDCToken,
       isAllowanceSet,
       walletAddress,
       transactionDebugLog,
@@ -1596,7 +1616,7 @@ export default function useRelaySell() {
   }, []);
 
   return {
-    getUSDCAddress,
+    getUSDCToken,
     getBestSellOffer,
     getBestSellOfferWithBridge,
     executeSell,

--- a/src/apps/pulse/hooks/useTopUp.ts
+++ b/src/apps/pulse/hooks/useTopUp.ts
@@ -32,11 +32,8 @@ export default function useTopUp() {
   const [error, setError] = useState<string | null>(null);
 
   const { kit, walletAddress } = useTransactionKit();
-  const {
-    buildSellTransactions,
-    getUSDCAddress,
-    isInitialized: isRelayInitialized,
-  } = useRelaySell();
+  const { buildSellTransactions, isInitialized: isRelayInitialized } =
+    useRelaySell();
   const { transactionDebugLog } = useTransactionDebugLogger();
 
   const clearError = useCallback(() => {
@@ -59,12 +56,6 @@ export default function useTopUp() {
 
       const transactions = [];
       const { chainId } = selectedToken;
-
-      // Get USDC address for the chain
-      const usdcAddress = getUSDCAddress(chainId);
-      if (!usdcAddress) {
-        throw new Error(`USDC not supported on chain ${chainId}`);
-      }
 
       // Step 1: If non-USDC token, add sell transactions
       if (sellOffer) {
@@ -154,7 +145,7 @@ export default function useTopUp() {
 
       return transactions;
     },
-    [walletAddress, getUSDCAddress, buildSellTransactions]
+    [walletAddress, buildSellTransactions]
   );
 
   /**


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Changed usdc decimals fetch to dynamic instead of hardcoded 6 since BNB chain USDC has 18 decimals

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stablecoin decimal precision handling across trading operations to ensure accurate token conversions and balance calculations.

* **Refactor**
  * Enhanced token data structures to include decimal information, enabling more reliable and consistent handling of different token types across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->