### PR TITLE
Fixes/BNB USDC Fix

### DIFF
--- a/src/apps/pulse/components/Buy/PayingToken.tsx
+++ b/src/apps/pulse/components/Buy/PayingToken.tsx
@@ -4,6 +4,7 @@ import { MdCheck } from 'react-icons/md';
 
 // utils
 import { getLogoForChainId } from '../../../../utils/blockchain';
+import { truncateDecimals } from '../../utils/number';
 
 // types
 import { PayingToken as PayingTokenType } from '../../types/tokens';
@@ -85,7 +86,7 @@ export default function PayingToken(props: PayingTokenProps) {
       </div>
       <div className="flex flex-col justify-center text-right">
         <div className="text-[13px] font-normal text-white">
-          {payingToken.totalRaw}
+          {truncateDecimals(payingToken.totalRaw, 6)}
         </div>
         <div className="text-xs font-normal text-white/50">
           ${payingToken.totalUsd.toFixed(2)}

--- a/src/apps/pulse/utils/number.ts
+++ b/src/apps/pulse/utils/number.ts
@@ -51,3 +51,18 @@ export function bigIntPow(base: bigint, exponent: bigint): bigint {
   }
   return result;
 }
+
+export function truncateDecimals(
+  value: string | number,
+  decimals: number
+): string {
+  const strValue = typeof value === 'number' ? value.toString() : value;
+  const [integerPart, decimalPart] = strValue.split('.');
+
+  if (!decimalPart) {
+    return integerPart;
+  }
+
+  const truncatedDecimal = decimalPart.slice(0, decimals);
+  return `${integerPart}.${truncatedDecimal}`;
+}

--- a/src/utils/pnl.ts
+++ b/src/utils/pnl.ts
@@ -18,6 +18,17 @@ const USDC_ADDRESSES = allStableCurrencies.map(
     currency.address.toLowerCase()
 );
 
+/**
+ * Get the USDC decimals for a specific chain
+ */
+const getUSDCDecimalsByChainId = (chainId: number): number => {
+  const usdcToken = allStableCurrencies.find(
+    (currency: { chainId: number; address: string; decimals: number }) =>
+      currency.chainId === chainId
+  ) as { chainId: number; address: string; decimals: number } | undefined;
+  return usdcToken?.decimals ?? 6; // Default to 6 if not found
+};
+
 export const reconstructTrades = (
   transactions: MobulaTransactionRow[],
   walletAddress: string
@@ -332,10 +343,12 @@ export const getRelayValidatedTrades = async (
 
                 // For BUY, we expect negative USDC (spending)
                 // For SELL, we expect positive USDC (receiving)
+                const usdcDecimals = getUSDCDecimalsByChainId(token.chainId);
+                const usdcDivisor = 10 ** usdcDecimals;
                 if (side === 'BUY' && balanceDiff < 0) {
-                  usdcAmount += Math.abs(balanceDiff) / 1e6; // USDC has 6 decimals
+                  usdcAmount += Math.abs(balanceDiff) / usdcDivisor;
                 } else if (side === 'SELL' && balanceDiff > 0) {
-                  usdcAmount += balanceDiff / 1e6;
+                  usdcAmount += balanceDiff / usdcDivisor;
                 }
               }
             });
@@ -438,7 +451,8 @@ export const calculatePnLFromRelay = (
       // If state changes show token movement, use that
       if (tokenChange !== 0) {
         const tokenDivisor = 10 ** token.decimals;
-        const usdcDivisor = 1e6;
+        const usdcDecimals = getUSDCDecimalsByChainId(token.chainId);
+        const usdcDivisor = 10 ** usdcDecimals;
 
         const tokenAmountRaw = Math.abs(tokenChange) / tokenDivisor;
         const usdcAmountRaw = Math.abs(usdcChange) / usdcDivisor;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- fixed hardcoding of USDC decimals on pnl
- restricted the USDC amount to 6 on preview buy

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token amount display precision with truncated decimals for cleaner UI presentation and better readability.
  * Enhanced profit/loss calculations to dynamically account for chain-specific USDC decimal configurations. Now properly normalizes amounts based on the blockchain network to ensure accurate calculations across different chains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->