### PR TITLE
🚀 Production release 

### DIFF
--- a/src/components/LandingPage/GlobalStyles/index.jsx
+++ b/src/components/LandingPage/GlobalStyles/index.jsx
@@ -279,13 +279,13 @@ ul li:last-child {
 
 .header__announcement {
   position: relative;
-  background: var(--light-blue);
+  background: #8a77ff;
   z-index: 101;
 }
 
 @media only screen and (max-width: 1024px) {
   .header__announcement {
-    background: rgba(94, 0, 255, 0.9);
+    background: #8a77ff;
   }
 }
 
@@ -298,18 +298,21 @@ ul li:last-child {
 }
 
 .header__announcement__wrapper p {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
   margin-bottom: 0;
   font-weight: 700;
 }
 
 .header__announcement__wrapper p a {
-  display: none;
   text-decoration: underline;
 }
 
 @media only screen and (max-width: 1023px) {
-  .header__announcement__wrapper p a {
+  .header__announcement__wrapper p {
+    font-size: 1.4rem;
+  }
+
+  .header__announcement__wrapper a {
     display: inline-block;
   }
 }

--- a/src/components/LandingPage/Header/index.jsx
+++ b/src/components/LandingPage/Header/index.jsx
@@ -9,6 +9,10 @@ const Header = () => {
   const [showMobileMenu, setShowMobileMenu] = useState(false);
   const [isVisible, setIsVisible] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
+  const announcement = {
+    show: true,
+    message: `<p>🚀Just in: PillarX Algorithmic Insights! Trade smarter with PillarX. <a href="https://go.pillarx.app/LY6ZNTS">Start your FREE 7-day trial</a></p>`,
+  };
 
   useEffect(() => {
     const controlNavbar = () => {
@@ -41,6 +45,15 @@ const Header = () => {
         className={`header ${isVisible ? '' : 'header--hidden'}`}
         id="header"
       >
+        {announcement.show && (
+          <div className="header__announcement">
+            <div
+              className="header__announcement__wrapper"
+              dangerouslySetInnerHTML={{ __html: announcement.message }}
+            />
+          </div>
+        )}
+
         <div className="container">
           <Link to="/" className="header__logo">
             <img

--- a/src/components/LandingPage/Header/index.jsx
+++ b/src/components/LandingPage/Header/index.jsx
@@ -11,7 +11,6 @@ const Header = () => {
   const [lastScrollY, setLastScrollY] = useState(0);
   const announcement = {
     show: true,
-    message: `<p>🚀Just in: PillarX Algorithmic Insights! Trade smarter with PillarX. <a href="https://go.pillarx.app/LY6ZNTS">Start your FREE 7-day trial</a></p>`,
   };
 
   useEffect(() => {
@@ -47,10 +46,15 @@ const Header = () => {
       >
         {announcement.show && (
           <div className="header__announcement">
-            <div
-              className="header__announcement__wrapper"
-              dangerouslySetInnerHTML={{ __html: announcement.message }}
-            />
+            <div className="header__announcement__wrapper">
+              <p>
+                🚀Just in: PillarX Algorithmic Insights! Trade smarter with
+                PillarX.{' '}
+                <a href="https://go.pillarx.app/LY6ZNTS">
+                  Start your FREE 7-day trial
+                </a>
+              </p>
+            </div>
           </div>
         )}
 

--- a/src/containers/__snapshots__/Main.test.tsx.snap
+++ b/src/containers/__snapshots__/Main.test.tsx.snap
@@ -7,6 +7,18 @@ exports[`<Main /> > renders correctly 1`] = `
     id="header"
   >
     <div
+      className="header__announcement"
+    >
+      <div
+        className="header__announcement__wrapper"
+        dangerouslySetInnerHTML={
+          {
+            "__html": "<p>🚀Just in: PillarX Algorithmic Insights! Trade smarter with PillarX. <a href="https://go.pillarx.app/LY6ZNTS">Start your FREE 7-day trial</a></p>",
+          }
+        }
+      />
+    </div>
+    <div
       className="container"
     >
       <a

--- a/src/containers/__snapshots__/Main.test.tsx.snap
+++ b/src/containers/__snapshots__/Main.test.tsx.snap
@@ -11,12 +11,17 @@ exports[`<Main /> > renders correctly 1`] = `
     >
       <div
         className="header__announcement__wrapper"
-        dangerouslySetInnerHTML={
-          {
-            "__html": "<p>🚀Just in: PillarX Algorithmic Insights! Trade smarter with PillarX. <a href="https://go.pillarx.app/LY6ZNTS">Start your FREE 7-day trial</a></p>",
-          }
-        }
-      />
+      >
+        <p>
+          🚀Just in: PillarX Algorithmic Insights! Trade smarter with PillarX.
+           
+          <a
+            href="https://go.pillarx.app/LY6ZNTS"
+          >
+            Start your FREE 7-day trial
+          </a>
+        </p>
+      </div>
     </div>
     <div
       className="container"


### PR DESCRIPTION
This **production release** is a small but very visible marketing upgrade: it adds a promo banner to the PillarX landing page that highlights **Algorithmic Insights** and a **free 7-day trial**, with styling tuned for both desktop and mobile. It’s a tight PR: **3 commits**, **3 files changed** (**+42 / −5**).

* **New “Algorithmic Insights” header announcement**
  The landing page header now includes an announcement strip:

  > “Just in: PillarX Algorithmic Insights! Trade smarter with PillarX. Start your FREE 7-day trial”
  > with a clear call-to-action link.

* **Mobile-friendly CTA**
  The announcement text and link are styled so the **“Start your FREE 7-day trial”** button is visible and tappable on smaller screens, instead of being hidden.

* **Polished banner styling**
  The banner background and typography were adjusted (consistent purple, bolder copy, tuned font sizes) so the message stands out without feeling shouty.

* **Snapshot updates to keep tests green**
  The main container snapshot was updated to reflect the new header, keeping the test suite in sync with the UI.