### PR TITLE
MTS Fee Calculation

### DIFF
--- a/src/apps/pillarx-app/components/TokenMarketDataRow/tests/__snapshots__/LeftColumnTokenMarketDataRow.test.tsx.snap
+++ b/src/apps/pillarx-app/components/TokenMarketDataRow/tests/__snapshots__/LeftColumnTokenMarketDataRow.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`<LeftColumnTokenMarketDataRow /> - ETH token row > renders and matches 
           <p
             class="text-sm font-medium font-normal text-white"
           >
-            8mo ago
+            9mo ago
           </p>
           <p
             class="text-sm font-medium font-normal mobile:hidden text-white"
@@ -106,7 +106,7 @@ exports[`<LeftColumnTokenMarketDataRow /> - ETH token row > renders and matches 
         <p
           class="text-sm font-medium font-normal text-white"
         >
-          8mo ago
+          9mo ago
         </p>
         <p
           class="text-sm font-medium font-normal mobile:hidden text-white"

--- a/src/apps/pillarx-app/components/TokensWithMarketDataTile/test/__snapshots__/TokensWithMarketDataTile.test.tsx.snap
+++ b/src/apps/pillarx-app/components/TokensWithMarketDataTile/test/__snapshots__/TokensWithMarketDataTile.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`<TokensWithMarketDataTile /> > renders and matches snapshot 1`] = `
                       <p
                         class="text-sm font-medium font-normal text-white"
                       >
-                        8mo ago
+                        9mo ago
                       </p>
                       <p
                         class="text-sm font-medium font-normal mobile:hidden text-white"
@@ -260,7 +260,7 @@ exports[`<TokensWithMarketDataTile /> > renders and matches snapshot 1`] = `
                       <p
                         class="text-sm font-medium font-normal text-white"
                       >
-                        8mo ago
+                        9mo ago
                       </p>
                       <p
                         class="text-sm font-medium font-normal mobile:hidden text-white"
@@ -421,7 +421,7 @@ exports[`<TokensWithMarketDataTile /> > renders and matches snapshot 1`] = `
                         <p
                           class="text-sm font-medium font-normal text-white"
                         >
-                          8mo ago
+                          9mo ago
                         </p>
                         <p
                           class="text-sm font-medium font-normal mobile:hidden text-white"
@@ -584,7 +584,7 @@ exports[`<TokensWithMarketDataTile /> > renders and matches snapshot 1`] = `
                         <p
                           class="text-sm font-medium font-normal text-white"
                         >
-                          8mo ago
+                          9mo ago
                         </p>
                         <p
                           class="text-sm font-medium font-normal mobile:hidden text-white"
@@ -774,7 +774,7 @@ exports[`<TokensWithMarketDataTile /> > renders and matches snapshot 1`] = `
                     <p
                       class="text-sm font-medium font-normal text-white"
                     >
-                      8mo ago
+                      9mo ago
                     </p>
                     <p
                       class="text-sm font-medium font-normal mobile:hidden text-white"
@@ -937,7 +937,7 @@ exports[`<TokensWithMarketDataTile /> > renders and matches snapshot 1`] = `
                     <p
                       class="text-sm font-medium font-normal text-white"
                     >
-                      8mo ago
+                      9mo ago
                     </p>
                     <p
                       class="text-sm font-medium font-normal mobile:hidden text-white"
@@ -1098,7 +1098,7 @@ exports[`<TokensWithMarketDataTile /> > renders and matches snapshot 1`] = `
                       <p
                         class="text-sm font-medium font-normal text-white"
                       >
-                        8mo ago
+                        9mo ago
                       </p>
                       <p
                         class="text-sm font-medium font-normal mobile:hidden text-white"
@@ -1261,7 +1261,7 @@ exports[`<TokensWithMarketDataTile /> > renders and matches snapshot 1`] = `
                       <p
                         class="text-sm font-medium font-normal text-white"
                       >
-                        8mo ago
+                        9mo ago
                       </p>
                       <p
                         class="text-sm font-medium font-normal mobile:hidden text-white"

--- a/src/apps/pulse/components/Onboarding/TopUpScreen.tsx
+++ b/src/apps/pulse/components/Onboarding/TopUpScreen.tsx
@@ -417,18 +417,6 @@ export default function TopUpScreen(props: TopUpScreenProps) {
 
         setEstimatedGasCostInToken(estimatedCostInTokenFixed);
 
-        // Log the calculated gasless fee for debugging
-        console.log(
-          `[Gasless Fee Estimate] ${selectedFeeAsset.asset.symbol}: ` +
-            `Gas Cost (wei): ${gasCost}, ` +
-            `Gas Price: ${gasPrice}, ` +
-            `Estimated Cost (ETH): ${estimatedCost}, ` +
-            `Native Price (USD): ${nativePriceData.priceUSD}, ` +
-            `Cost in Fiat (USD): ${costAsFiat}, ` +
-            `Fee Token Price: ${feeTokenPrice}, ` +
-            `Final Cost in ${selectedFeeAsset.asset.symbol}: ${estimatedCostInTokenFixed}`
-        );
-
         // Check if user has enough balance for both topup amount AND gas fee
         const userBalance = selectedFeeAsset.balance ?? 0;
         const tokenPrice = parseFloat(selectedFeeAsset.tokenPrice || '0') || 1; // Default to 1 if price unavailable
@@ -437,7 +425,8 @@ export default function TopUpScreen(props: TopUpScreenProps) {
         // calculate remaining balance after deducting the topup amount
         // Convert topup amount from USD to token units using token price
         const topUpAmountUSD = parseFloat(amount) || 0;
-        const topUpAmountInTokens = tokenPrice > 0 ? topUpAmountUSD / tokenPrice : 0;
+        const topUpAmountInTokens =
+          tokenPrice > 0 ? topUpAmountUSD / tokenPrice : 0;
 
         const isFeeSameAsToken =
           selectedFeeAsset.asset.contract.toLowerCase() ===
@@ -449,16 +438,17 @@ export default function TopUpScreen(props: TopUpScreenProps) {
         }
 
         if (availableBalanceForFee < estimatedCostInToken) {
-          const totalNeededInTokens = topUpAmountInTokens + estimatedCostInToken;
+          const totalNeededInTokens =
+            topUpAmountInTokens + estimatedCostInToken;
           setError(
             isFeeSameAsToken
               ? `Insufficient ${selectedFeeAsset.asset.symbol} balance. ` +
-                `Need ${topUpAmountInTokens.toFixed(selectedFeeAsset.decimals)} to top up + ` +
-                `${estimatedCostInTokenFixed} for gas = ${totalNeededInTokens.toFixed(selectedFeeAsset.decimals)} total, ` +
-                `but only have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
+                  `Need ${topUpAmountInTokens.toFixed(selectedFeeAsset.decimals)} to top up + ` +
+                  `${estimatedCostInTokenFixed} for gas = ${totalNeededInTokens.toFixed(selectedFeeAsset.decimals)} total, ` +
+                  `but only have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
               : `Insufficient ${selectedFeeAsset.asset.symbol} balance for gas fees. ` +
-                `Need ${estimatedCostInTokenFixed} ${selectedFeeAsset.asset.symbol}, ` +
-                `have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
+                  `Need ${estimatedCostInTokenFixed} ${selectedFeeAsset.asset.symbol}, ` +
+                  `have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
           );
           setApproveData(''); // Clear approval data
           return;
@@ -628,7 +618,8 @@ export default function TopUpScreen(props: TopUpScreenProps) {
 
     // Convert topup amount (USD) to token units
     const topUpAmountUSD = parseFloat(amount) || 0;
-    const topUpAmountInTokens = tokenPrice > 0 ? topUpAmountUSD / tokenPrice : 0;
+    const topUpAmountInTokens =
+      tokenPrice > 0 ? topUpAmountUSD / tokenPrice : 0;
 
     // Check if fee token is the same as topup token
     const isFeeSameAsToken =
@@ -647,12 +638,12 @@ export default function TopUpScreen(props: TopUpScreenProps) {
       setError(
         isFeeSameAsToken
           ? `Insufficient ${selectedFeeAsset.asset.symbol} balance. ` +
-            `Need ${topUpAmountInTokens.toFixed(selectedFeeAsset.decimals)} to top up + ` +
-            `${estimatedGasCostInToken} for gas = ${totalNeededInTokens.toFixed(selectedFeeAsset.decimals)} total, ` +
-            `but only have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
+              `Need ${topUpAmountInTokens.toFixed(selectedFeeAsset.decimals)} to top up + ` +
+              `${estimatedGasCostInToken} for gas = ${totalNeededInTokens.toFixed(selectedFeeAsset.decimals)} total, ` +
+              `but only have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
           : `Insufficient ${selectedFeeAsset.asset.symbol} balance for gas fees. ` +
-            `Need ${estimatedGasCostInToken} ${selectedFeeAsset.asset.symbol}, ` +
-            `have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
+              `Need ${estimatedGasCostInToken} ${selectedFeeAsset.asset.symbol}, ` +
+              `have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
       );
       return false;
     }
@@ -1012,7 +1003,9 @@ export default function TopUpScreen(props: TopUpScreenProps) {
           <div className="m-2.5 p-3 bg-[#1E1D24] rounded-[10px] border border-[#29292F]">
             <div className="flex flex-col gap-2">
               <div className="flex items-center justify-between">
-                <span className="text-white/70 text-xs">Estimated Gas Fee:</span>
+                <span className="text-white/70 text-xs">
+                  Estimated Gas Fee:
+                </span>
                 <span className="text-white font-medium text-sm">
                   ≈ {estimatedGasCostInToken} {selectedFeeAsset.asset.symbol}
                 </span>
@@ -1020,7 +1013,9 @@ export default function TopUpScreen(props: TopUpScreenProps) {
               <div className="flex items-center justify-between text-xs">
                 <span className="text-white/50">Total needed:</span>
                 <span className="text-white">
-                  {(parseFloat(amount) + parseFloat(estimatedGasCostInToken)).toFixed(selectedFeeAsset.decimals)}{' '}
+                  {(
+                    parseFloat(amount) + parseFloat(estimatedGasCostInToken)
+                  ).toFixed(selectedFeeAsset.decimals)}{' '}
                   {selectedFeeAsset.asset.symbol}
                 </span>
               </div>

--- a/src/apps/pulse/components/Onboarding/TopUpScreen.tsx
+++ b/src/apps/pulse/components/Onboarding/TopUpScreen.tsx
@@ -324,7 +324,7 @@ export default function TopUpScreen(props: TopUpScreenProps) {
             });
             setSelectedPaymasterAddress(matchingPaymaster.paymasterAddress);
 
-            // Fetch gas price for calculations
+            // Fetch actual gas price from chain for accurate fee estimation
             const price = await getGasPrice(selectedToken.chainId);
             if (price) setGasPrice(price);
           }
@@ -417,13 +417,48 @@ export default function TopUpScreen(props: TopUpScreenProps) {
 
         setEstimatedGasCostInToken(estimatedCostInTokenFixed);
 
-        // Check if user has enough balance
+        // Log the calculated gasless fee for debugging
+        console.log(
+          `[Gasless Fee Estimate] ${selectedFeeAsset.asset.symbol}: ` +
+            `Gas Cost (wei): ${gasCost}, ` +
+            `Gas Price: ${gasPrice}, ` +
+            `Estimated Cost (ETH): ${estimatedCost}, ` +
+            `Native Price (USD): ${nativePriceData.priceUSD}, ` +
+            `Cost in Fiat (USD): ${costAsFiat}, ` +
+            `Fee Token Price: ${feeTokenPrice}, ` +
+            `Final Cost in ${selectedFeeAsset.asset.symbol}: ${estimatedCostInTokenFixed}`
+        );
+
+        // Check if user has enough balance for both topup amount AND gas fee
         const userBalance = selectedFeeAsset.balance ?? 0;
-        if (userBalance < estimatedCostInToken) {
+        const tokenPrice = parseFloat(selectedFeeAsset.tokenPrice || '0') || 1; // Default to 1 if price unavailable
+
+        // When the fee token is the same as the topup token,
+        // calculate remaining balance after deducting the topup amount
+        // Convert topup amount from USD to token units using token price
+        const topUpAmountUSD = parseFloat(amount) || 0;
+        const topUpAmountInTokens = tokenPrice > 0 ? topUpAmountUSD / tokenPrice : 0;
+
+        const isFeeSameAsToken =
+          selectedFeeAsset.asset.contract.toLowerCase() ===
+          selectedToken.address.toLowerCase();
+
+        let availableBalanceForFee = userBalance;
+        if (isFeeSameAsToken) {
+          availableBalanceForFee = userBalance - topUpAmountInTokens;
+        }
+
+        if (availableBalanceForFee < estimatedCostInToken) {
+          const totalNeededInTokens = topUpAmountInTokens + estimatedCostInToken;
           setError(
-            `Insufficient ${selectedFeeAsset.asset.symbol} balance for gas fees. ` +
-              `Need ${estimatedCostInTokenFixed} ${selectedFeeAsset.asset.symbol}, ` +
-              `have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
+            isFeeSameAsToken
+              ? `Insufficient ${selectedFeeAsset.asset.symbol} balance. ` +
+                `Need ${topUpAmountInTokens.toFixed(selectedFeeAsset.decimals)} to top up + ` +
+                `${estimatedCostInTokenFixed} for gas = ${totalNeededInTokens.toFixed(selectedFeeAsset.decimals)} total, ` +
+                `but only have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
+              : `Insufficient ${selectedFeeAsset.asset.symbol} balance for gas fees. ` +
+                `Need ${estimatedCostInTokenFixed} ${selectedFeeAsset.asset.symbol}, ` +
+                `have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
           );
           setApproveData(''); // Clear approval data
           return;
@@ -576,6 +611,55 @@ export default function TopUpScreen(props: TopUpScreenProps) {
     }
   };
 
+  /**
+   * Validates that the user has sufficient balance for gasless transactions.
+   * This checks that: user_balance >= topup_amount_in_tokens + gas_fee_in_tokens
+   * Returns true if validation passes, false otherwise (with error message set)
+   */
+  const validateGaslessFeeBalance = (): boolean => {
+    // Only validate if gasless is supported and we have the necessary data
+    if (!isGaslessSupported || !selectedFeeAsset || !estimatedGasCostInToken) {
+      return true; // Skip validation if not using gasless
+    }
+
+    const userBalance = selectedFeeAsset.balance ?? 0;
+    const tokenPrice = parseFloat(selectedFeeAsset.tokenPrice || '0') || 1;
+    const estimatedGasInToken = parseFloat(estimatedGasCostInToken);
+
+    // Convert topup amount (USD) to token units
+    const topUpAmountUSD = parseFloat(amount) || 0;
+    const topUpAmountInTokens = tokenPrice > 0 ? topUpAmountUSD / tokenPrice : 0;
+
+    // Check if fee token is the same as topup token
+    const isFeeSameAsToken =
+      selectedFeeAsset.asset.contract.toLowerCase() ===
+      selectedToken?.address.toLowerCase();
+
+    // Calculate available balance for fee
+    let availableBalanceForFee = userBalance;
+    if (isFeeSameAsToken) {
+      availableBalanceForFee = userBalance - topUpAmountInTokens;
+    }
+
+    // Validate balance is sufficient
+    if (availableBalanceForFee < estimatedGasInToken) {
+      const totalNeededInTokens = topUpAmountInTokens + estimatedGasInToken;
+      setError(
+        isFeeSameAsToken
+          ? `Insufficient ${selectedFeeAsset.asset.symbol} balance. ` +
+            `Need ${topUpAmountInTokens.toFixed(selectedFeeAsset.decimals)} to top up + ` +
+            `${estimatedGasCostInToken} for gas = ${totalNeededInTokens.toFixed(selectedFeeAsset.decimals)} total, ` +
+            `but only have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
+          : `Insufficient ${selectedFeeAsset.asset.symbol} balance for gas fees. ` +
+            `Need ${estimatedGasCostInToken} ${selectedFeeAsset.asset.symbol}, ` +
+            `have ${userBalance.toFixed(selectedFeeAsset.decimals)} ${selectedFeeAsset.asset.symbol}`
+      );
+      return false;
+    }
+
+    return true;
+  };
+
   const handleTopUp = () => {
     // Validation
     const numAmount = parseFloat(amount);
@@ -611,10 +695,9 @@ export default function TopUpScreen(props: TopUpScreenProps) {
       return;
     }
 
-    // If using gasless, check if we have approval data (which means balance is sufficient)
-    if (isGaslessSupported && selectedFeeAsset && !approveData) {
-      // Error already set in generateApprovalData
-      return;
+    // Validate gasless fee balance before proceeding
+    if (!validateGaslessFeeBalance()) {
+      return; // Error message already set by validateGaslessFeeBalance
     }
 
     // Clear any previous errors
@@ -919,6 +1002,41 @@ export default function TopUpScreen(props: TopUpScreenProps) {
                     +
                   </button>
                 </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Gasless Fee Estimate - Show when USDC is selected */}
+        {isGaslessSupported && selectedFeeAsset && estimatedGasCostInToken && (
+          <div className="m-2.5 p-3 bg-[#1E1D24] rounded-[10px] border border-[#29292F]">
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <span className="text-white/70 text-xs">Estimated Gas Fee:</span>
+                <span className="text-white font-medium text-sm">
+                  ≈ {estimatedGasCostInToken} {selectedFeeAsset.asset.symbol}
+                </span>
+              </div>
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-white/50">Total needed:</span>
+                <span className="text-white">
+                  {(parseFloat(amount) + parseFloat(estimatedGasCostInToken)).toFixed(selectedFeeAsset.decimals)}{' '}
+                  {selectedFeeAsset.asset.symbol}
+                </span>
+              </div>
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-white/50">Your balance:</span>
+                <span
+                  className={
+                    selectedFeeAsset.balance >=
+                    parseFloat(amount) + parseFloat(estimatedGasCostInToken)
+                      ? 'text-[#10B981]'
+                      : 'text-[#EF4444]'
+                  }
+                >
+                  {selectedFeeAsset.balance.toFixed(selectedFeeAsset.decimals)}{' '}
+                  {selectedFeeAsset.asset.symbol}
+                </span>
               </div>
             </div>
           </div>

--- a/src/apps/pulse/components/Onboarding/TopUpScreen.tsx
+++ b/src/apps/pulse/components/Onboarding/TopUpScreen.tsx
@@ -1006,8 +1006,9 @@ export default function TopUpScreen(props: TopUpScreenProps) {
                 // Convert USD amount to token units using token price
                 const tokenPrice =
                   parseFloat(selectedFeeAsset.tokenPrice || '0') || 1;
-                const topUpAmountInTokens = parseFloat(amount) / tokenPrice;
-                const gasInTokens = parseFloat(estimatedGasCostInToken);
+                const topUpAmountInTokens =
+                  (parseFloat(amount) || 0) / tokenPrice;
+                const gasInTokens = parseFloat(estimatedGasCostInToken) || 0;
                 const totalNeededInTokens = topUpAmountInTokens + gasInTokens;
                 const hasEnoughBalance =
                   selectedFeeAsset.balance >= totalNeededInTokens;

--- a/src/apps/pulse/components/Onboarding/TopUpScreen.tsx
+++ b/src/apps/pulse/components/Onboarding/TopUpScreen.tsx
@@ -1002,37 +1002,47 @@ export default function TopUpScreen(props: TopUpScreenProps) {
         {isGaslessSupported && selectedFeeAsset && estimatedGasCostInToken && (
           <div className="m-2.5 p-3 bg-[#1E1D24] rounded-[10px] border border-[#29292F]">
             <div className="flex flex-col gap-2">
-              <div className="flex items-center justify-between">
-                <span className="text-white/70 text-xs">
-                  Estimated Gas Fee:
-                </span>
-                <span className="text-white font-medium text-sm">
-                  ≈ {estimatedGasCostInToken} {selectedFeeAsset.asset.symbol}
-                </span>
-              </div>
-              <div className="flex items-center justify-between text-xs">
-                <span className="text-white/50">Total needed:</span>
-                <span className="text-white">
-                  {(
-                    parseFloat(amount) + parseFloat(estimatedGasCostInToken)
-                  ).toFixed(selectedFeeAsset.decimals)}{' '}
-                  {selectedFeeAsset.asset.symbol}
-                </span>
-              </div>
-              <div className="flex items-center justify-between text-xs">
-                <span className="text-white/50">Your balance:</span>
-                <span
-                  className={
-                    selectedFeeAsset.balance >=
-                    parseFloat(amount) + parseFloat(estimatedGasCostInToken)
-                      ? 'text-[#10B981]'
-                      : 'text-[#EF4444]'
-                  }
-                >
-                  {selectedFeeAsset.balance.toFixed(selectedFeeAsset.decimals)}{' '}
-                  {selectedFeeAsset.asset.symbol}
-                </span>
-              </div>
+              {(() => {
+                // Convert USD amount to token units using token price
+                const tokenPrice = parseFloat(selectedFeeAsset.tokenPrice || '0') || 1;
+                const topUpAmountInTokens = parseFloat(amount) / tokenPrice;
+                const gasInTokens = parseFloat(estimatedGasCostInToken);
+                const totalNeededInTokens = topUpAmountInTokens + gasInTokens;
+                const hasEnoughBalance = selectedFeeAsset.balance >= totalNeededInTokens;
+
+                return (
+                  <>
+                    <div className="flex items-center justify-between">
+                      <span className="text-white/70 text-xs">
+                        Estimated Gas Fee:
+                      </span>
+                      <span className="text-white font-medium text-sm">
+                        ≈ {estimatedGasCostInToken} {selectedFeeAsset.asset.symbol}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="text-white/50">Total needed:</span>
+                      <span className="text-white">
+                        {totalNeededInTokens.toFixed(selectedFeeAsset.decimals)}{' '}
+                        {selectedFeeAsset.asset.symbol}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="text-white/50">Your balance:</span>
+                      <span
+                        className={
+                          hasEnoughBalance
+                            ? 'text-[#10B981]'
+                            : 'text-[#EF4444]'
+                        }
+                      >
+                        {selectedFeeAsset.balance.toFixed(selectedFeeAsset.decimals)}{' '}
+                        {selectedFeeAsset.asset.symbol}
+                      </span>
+                    </div>
+                  </>
+                );
+              })()}
             </div>
           </div>
         )}

--- a/src/apps/pulse/components/Onboarding/TopUpScreen.tsx
+++ b/src/apps/pulse/components/Onboarding/TopUpScreen.tsx
@@ -1004,11 +1004,13 @@ export default function TopUpScreen(props: TopUpScreenProps) {
             <div className="flex flex-col gap-2">
               {(() => {
                 // Convert USD amount to token units using token price
-                const tokenPrice = parseFloat(selectedFeeAsset.tokenPrice || '0') || 1;
+                const tokenPrice =
+                  parseFloat(selectedFeeAsset.tokenPrice || '0') || 1;
                 const topUpAmountInTokens = parseFloat(amount) / tokenPrice;
                 const gasInTokens = parseFloat(estimatedGasCostInToken);
                 const totalNeededInTokens = topUpAmountInTokens + gasInTokens;
-                const hasEnoughBalance = selectedFeeAsset.balance >= totalNeededInTokens;
+                const hasEnoughBalance =
+                  selectedFeeAsset.balance >= totalNeededInTokens;
 
                 return (
                   <>
@@ -1017,7 +1019,8 @@ export default function TopUpScreen(props: TopUpScreenProps) {
                         Estimated Gas Fee:
                       </span>
                       <span className="text-white font-medium text-sm">
-                        ≈ {estimatedGasCostInToken} {selectedFeeAsset.asset.symbol}
+                        ≈ {estimatedGasCostInToken}{' '}
+                        {selectedFeeAsset.asset.symbol}
                       </span>
                     </div>
                     <div className="flex items-center justify-between text-xs">
@@ -1031,12 +1034,12 @@ export default function TopUpScreen(props: TopUpScreenProps) {
                       <span className="text-white/50">Your balance:</span>
                       <span
                         className={
-                          hasEnoughBalance
-                            ? 'text-[#10B981]'
-                            : 'text-[#EF4444]'
+                          hasEnoughBalance ? 'text-[#10B981]' : 'text-[#EF4444]'
                         }
                       >
-                        {selectedFeeAsset.balance.toFixed(selectedFeeAsset.decimals)}{' '}
+                        {selectedFeeAsset.balance.toFixed(
+                          selectedFeeAsset.decimals
+                        )}{' '}
                         {selectedFeeAsset.asset.symbol}
                       </span>
                     </div>

--- a/src/services/gasless.ts
+++ b/src/services/gasless.ts
@@ -19,12 +19,12 @@ export const GasConsumptions = {
   nft: 630000,
   nft_arb: 1050000,
   // TopUp-specific gas costs
-  topup_install_modules: 500000,
-  topup_install_modules_arb: 700000, // 500000 + 200000
-  topup_deposit: 500000,
-  topup_deposit_arb: 700000,
-  topup_swap: 1500000,
-  topup_swap_arb: 1700000,
+  topup_install_modules: 610000,
+  topup_install_modules_arb: 810000, // 610000 + 200000
+  topup_deposit: 610000,
+  topup_deposit_arb: 810000,
+  topup_swap: 1610000,
+  topup_swap_arb: 1810000,
 };
 
 export const getAllGaslessPaymasters = async (


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Showed the estimated fee calculation if its USDC for MTS paymaster on top up screen
- Added some more gas as the gas limit was higher in recent transactions from bundler

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested locally
https://etherscan.io/tx/0x81a4fae499f06e93c0530eab3a32497988069e620e6e12bd290a140c95acaaec

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gasless Fee Estimate panel: shows estimated gas fee (token), total required (top-up + gas), and balance status; displayed only when gasless is supported and a fee asset is selected.

* **Improvements**
  * Centralized token-aware balance validation for gasless top-ups; validation runs before proceeding and adjusts checks when fee token matches top-up token.
  * Improved error messaging for gasless vs native flows.
  * Updated (higher) gas estimates for top-up operations.
  * Approval flow now accounts for gasless balance validation and potential fee-token approval needs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->