### PR TITLE
feat: Add Perps tile to homefeed with Hyperliquid branding

### DIFF
--- a/src/apps/pillarx-app/components/AccountSelector/AccountSelector.tsx
+++ b/src/apps/pillarx-app/components/AccountSelector/AccountSelector.tsx
@@ -1,0 +1,362 @@
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { usePrivy } from '@privy-io/react-auth';
+
+// services
+import { useGetWalletPortfolioQuery } from '../../../../services/pillarXApiWalletPortfolio';
+
+// hooks
+import useTransactionKit from '../../../../hooks/useTransactionKit';
+import { useAppDispatch, useAppSelector } from '../../hooks/useReducerHooks';
+
+// reducer
+import { setActiveAccountMode } from '../../reducer/WalletPortfolioSlice';
+
+// images
+import WalletPortfolioIcon from '../../images/wallet-portfolio-icon.png';
+
+const AccountSelector = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const dispatch = useAppDispatch();
+
+  const { user } = usePrivy();
+  const { walletAddress } = useTransactionKit();
+  const activeAccountMode = useAppSelector(
+    (state) => state.walletPortfolio.activeAccountMode
+  );
+
+  const eoaAddress = user?.wallet?.address;
+  const smartAddress = walletAddress;
+
+  // Fetch portfolio data for both accounts
+  const { data: smartPortfolioData } = useGetWalletPortfolioQuery(
+    { wallet: smartAddress || '', isPnl: false },
+    { skip: !smartAddress }
+  );
+
+  const { data: eoaPortfolioData } = useGetWalletPortfolioQuery(
+    { wallet: eoaAddress || '', isPnl: false },
+    { skip: !eoaAddress }
+  );
+
+  // Calculate balances
+  const smartBalance = useMemo(() => {
+    return smartPortfolioData?.result?.data?.total_wallet_balance || 0;
+  }, [smartPortfolioData]);
+
+  const eoaBalance = useMemo(() => {
+    return eoaPortfolioData?.result?.data?.total_wallet_balance || 0;
+  }, [eoaPortfolioData]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  const truncateAddress = (address: string) => {
+    if (!address) return '';
+    return `${address.slice(0, 6)}...${address.slice(-4)}`;
+  };
+
+  const handleSelectAccount = (account: 'eoa' | 'smart') => {
+    dispatch(setActiveAccountMode(account));
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+      >
+        <img
+          src={WalletPortfolioIcon}
+          alt="wallet-portfolio-icon"
+          className="w-8 h-6"
+        />
+        <div className="flex flex-col items-start">
+          <div className="flex items-center gap-1.5">
+            <span className="text-white text-sm font-medium">My portfolio</span>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              className={`transition-transform ${isOpen ? 'rotate-180' : ''}`}
+            >
+              <path
+                d="M4 6L8 10L12 6"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
+          <span className="text-white/50 text-[11px]">Managing 2 Accounts</span>
+        </div>
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full left-0 mt-2 w-[280px] bg-lighter_container_grey rounded-xl border border-white/[.05] shadow-lg z-50">
+          <div
+            onClick={() => handleSelectAccount('smart')}
+            className={`flex items-center justify-between px-4 py-2 hover:bg-white/[.05] cursor-pointer transition-colors ${
+              activeAccountMode === 'smart'
+                ? 'bg-white/[.08] border-l-2 border-purple_medium'
+                : ''
+            }`}
+          >
+            <div className="flex flex-col flex-1">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="text-white text-[14px] font-medium">
+                    Smart Account
+                  </span>
+                  {activeAccountMode === 'smart' && (
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 20 20"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16.6667 5L7.50004 14.1667L3.33337 10"
+                        stroke="#10B981"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-white text-[14px] font-medium">
+                    ${smartBalance.toFixed(2)}
+                  </span>
+                  <div
+                    className="relative group"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 14 14"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="cursor-pointer opacity-50 hover:opacity-100 transition-opacity"
+                    >
+                      <circle
+                        cx="7"
+                        cy="7"
+                        r="6.5"
+                        stroke="white"
+                        strokeWidth="1"
+                      />
+                      <text
+                        x="7"
+                        y="10"
+                        fontSize="10"
+                        fill="white"
+                        textAnchor="middle"
+                        fontWeight="bold"
+                      >
+                        i
+                      </text>
+                    </svg>
+                    <div className="hidden group-hover:block absolute bottom-full right-0 mb-2 w-[200px] bg-lighter_container_grey text-white text-[11px] px-3 py-2 rounded shadow-lg border border-white/[.05] z-[100]">
+                      <div className="font-semibold mb-1.5">Smart Account</div>
+                      <div className="flex items-start gap-1.5 mb-1">
+                        <span className="text-green-500">✓</span>
+                        <span>Batch transactions</span>
+                      </div>
+                      <div className="flex items-start gap-1.5 mb-1">
+                        <span className="text-green-500">✓</span>
+                        <span>Universal Gas Tank</span>
+                      </div>
+                      <div className="flex items-start gap-1.5">
+                        <span className="text-green-500">✓</span>
+                        <span>Chain Abstraction</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="text-white/50 text-[12px]">
+                  {truncateAddress(smartAddress || '')}
+                </span>
+                <svg
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    navigator.clipboard.writeText(smartAddress || '');
+                  }}
+                  width="12"
+                  height="12"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="cursor-pointer opacity-50 hover:opacity-100 transition-opacity"
+                >
+                  <rect
+                    x="5"
+                    y="5"
+                    width="9"
+                    height="9"
+                    rx="1"
+                    stroke="white"
+                    strokeWidth="1.5"
+                  />
+                  <path
+                    d="M3 11V3C3 2.44772 3.44772 2 4 2H10"
+                    stroke="white"
+                    strokeWidth="1.5"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          <div
+            onClick={() => handleSelectAccount('eoa')}
+            className={`flex items-center justify-between px-4 py-2 hover:bg-white/[.05] cursor-pointer transition-colors ${
+              activeAccountMode === 'eoa'
+                ? 'bg-white/[.08] border-l-2 border-purple_medium'
+                : ''
+            }`}
+          >
+            <div className="flex flex-col flex-1">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="text-white text-[14px] font-medium">
+                    EOA
+                  </span>
+                  {activeAccountMode === 'eoa' && (
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 20 20"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16.6667 5L7.50004 14.1667L3.33337 10"
+                        stroke="#10B981"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-white text-[14px] font-medium">
+                    ${eoaBalance.toFixed(2)}
+                  </span>
+                  <div
+                    className="relative group"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 14 14"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="cursor-pointer opacity-50 hover:opacity-100 transition-opacity"
+                    >
+                      <circle
+                        cx="7"
+                        cy="7"
+                        r="6.5"
+                        stroke="white"
+                        strokeWidth="1"
+                      />
+                      <text
+                        x="7"
+                        y="10"
+                        fontSize="10"
+                        fill="white"
+                        textAnchor="middle"
+                        fontWeight="bold"
+                      >
+                        i
+                      </text>
+                    </svg>
+                    <div className="hidden group-hover:block absolute bottom-full right-0 mb-2 w-[200px] bg-lighter_container_grey text-white text-[11px] px-3 py-2 rounded shadow-lg border border-white/[.05] z-[100]">
+                      <div className="font-semibold mb-1.5">EOA</div>
+                      <div className="flex items-start gap-1.5 mb-1">
+                        <span className="text-red-500">✗</span>
+                        <span>Gas Tokens needed</span>
+                      </div>
+                      <div className="flex items-start gap-1.5 mb-1">
+                        <span className="text-red-500">✗</span>
+                        <span>Batch transactions</span>
+                      </div>
+                      <div className="flex items-start gap-1.5">
+                        <span className="text-red-500">✗</span>
+                        <span>Network Switching</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="text-white/50 text-[12px]">
+                  {truncateAddress(eoaAddress || '')}
+                </span>
+                <svg
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    navigator.clipboard.writeText(eoaAddress || '');
+                  }}
+                  width="12"
+                  height="12"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="cursor-pointer opacity-50 hover:opacity-100 transition-opacity"
+                >
+                  <rect
+                    x="5"
+                    y="5"
+                    width="9"
+                    height="9"
+                    rx="1"
+                    stroke="white"
+                    strokeWidth="1.5"
+                  />
+                  <path
+                    d="M3 11V3C3 2.44772 3.44772 2 4 2H10"
+                    stroke="white"
+                    strokeWidth="1.5"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AccountSelector;

--- a/src/apps/pillarx-app/components/PerpsTile/PerpsTile.tsx
+++ b/src/apps/pillarx-app/components/PerpsTile/PerpsTile.tsx
@@ -1,0 +1,35 @@
+import { useNavigate } from 'react-router-dom';
+import TileContainer from '../TileContainer/TileContainer';
+
+const PerpsTile = () => {
+  const navigate = useNavigate();
+
+  const handleNavigateToPerps = () => {
+    navigate('/perps');
+  };
+
+  return (
+    <TileContainer id="perps-tile">
+      <button type="button" onClick={handleNavigateToPerps} className="w-full">
+        <div className="flex flex-col rounded-2xl bg-gradient-to-br from-purple-600 via-purple-500 to-pink-500 desktop:min-h-[320px] tablet:min-h-[280px] mobile:min-h-[240px] justify-end p-10 mobile:p-4 hover:opacity-90 transition-opacity cursor-pointer">
+          <div className="flex flex-col gap-4">
+            <p className="text-[45px] font-medium tablet:leading-[67.5px] desktop:leading-[67.5px] mobile:text-xl mobile:leading-[30px] text-white text-left">
+              Perps are here with Hyperliquid
+            </p>
+            <p className="font-medium desktop:text-[22px] tablet:text-[22px] tablet:leading-[33px] desktop:leading-[33px] mobile:text-sm text-white/90 text-left">
+              Start trading with short and long positions up to 50x with
+              Hyperliquid
+            </p>
+            <div className="mt-6 mobile:mt-2">
+              <span className="font-medium bg-white/20 backdrop-blur-sm rounded-md py-3 px-5 mobile:text-sm mobile:py-2 mobile:px-4 text-white inline-block">
+                Start Trading →
+              </span>
+            </div>
+          </div>
+        </div>
+      </button>
+    </TileContainer>
+  );
+};
+
+export default PerpsTile;

--- a/src/apps/pillarx-app/components/WalletPortfolioBalance/WalletPortfolioBalance.tsx
+++ b/src/apps/pillarx-app/components/WalletPortfolioBalance/WalletPortfolioBalance.tsx
@@ -12,9 +12,9 @@ import { setIsRefreshAll } from '../../reducer/WalletPortfolioSlice';
 
 // images
 import RefreshIcon from '../../images/refresh-button.png';
-import WalletPortfolioIcon from '../../images/wallet-portfolio-icon.png';
 
 // components
+import AccountSelector from '../AccountSelector/AccountSelector';
 import SkeletonLoader from '../../../../components/SkeletonLoader';
 import Body from '../Typography/Body';
 import BodySmall from '../Typography/BodySmall';
@@ -79,14 +79,7 @@ const WalletPortfolioBalance = () => {
   return (
     <div className="flex w-full justify-between">
       <div className="flex flex-col gap-4">
-        <div className="flex gap-1.5">
-          <img
-            src={WalletPortfolioIcon}
-            alt="wallet-portfolio-icon"
-            className="w-7 h-5"
-          />
-          <Body>My portfolio</Body>
-        </div>
+        <AccountSelector />
         {isWalletPortfolioLoading || !walletPortfolio ? (
           <SkeletonLoader $height="45px" $width="150px" $radius="10px" />
         ) : (

--- a/src/apps/pillarx-app/components/WalletPortfolioBalance/test/WalletPortfolioBalance.test.tsx
+++ b/src/apps/pillarx-app/components/WalletPortfolioBalance/test/WalletPortfolioBalance.test.tsx
@@ -34,6 +34,12 @@ vi.mock('../../../images/wallet-portfolio-icon.png', () => {
     default: 'wallet-portfolio-icon.png',
   };
 });
+vi.mock('../../AccountSelector/AccountSelector', () => ({
+  __esModule: true,
+  default: function AccountSelector() {
+    return <div data-testid="account-selector">Account Selector</div>;
+  },
+}));
 
 const mockDispatch = vi.fn();
 (useAppDispatchMock as unknown as Mock).mockReturnValue(mockDispatch);
@@ -96,7 +102,6 @@ describe('WalletPortfolioBalance', () => {
     });
 
     expect(screen.getByText('$0.00')).toBeInTheDocument();
-    expect(screen.getByAltText('wallet-portfolio-icon')).toBeInTheDocument();
   });
 
   it('renders balance with positive change', () => {

--- a/src/apps/pillarx-app/components/WalletPortfolioBalance/test/__snapshots__/WalletPortfolioBalance.test.tsx.snap
+++ b/src/apps/pillarx-app/components/WalletPortfolioBalance/test/__snapshots__/WalletPortfolioBalance.test.tsx.snap
@@ -12,18 +12,9 @@ exports[`WalletPortfolioBalance > renders correctly and matches snapshot 1`] = `
           class="flex flex-col gap-4"
         >
           <div
-            class="flex gap-1.5"
+            data-testid="account-selector"
           >
-            <img
-              alt="wallet-portfolio-icon"
-              class="w-7 h-5"
-              src="wallet-portfolio-icon.png"
-            />
-            <p
-              class="text-base font-medium undefined"
-            >
-              My portfolio
-            </p>
+            Account Selector
           </div>
           <div
             data-testid="skeleton-loader"
@@ -51,18 +42,9 @@ exports[`WalletPortfolioBalance > renders correctly and matches snapshot 1`] = `
         class="flex flex-col gap-4"
       >
         <div
-          class="flex gap-1.5"
+          data-testid="account-selector"
         >
-          <img
-            alt="wallet-portfolio-icon"
-            class="w-7 h-5"
-            src="wallet-portfolio-icon.png"
-          />
-          <p
-            class="text-base font-medium undefined"
-          >
-            My portfolio
-          </p>
+          Account Selector
         </div>
         <div
           data-testid="skeleton-loader"

--- a/src/apps/pillarx-app/index.tsx
+++ b/src/apps/pillarx-app/index.tsx
@@ -37,6 +37,7 @@ import AnimatedTile from './components/AnimatedTile/AnimatedTitle';
 import SkeletonTiles from './components/SkeletonTile/SkeletonTile';
 import Body from './components/Typography/Body';
 import WalletPortfolioTile from './components/WalletPortfolioTile/WalletPortfolioTile';
+import PerpsTile from './components/PerpsTile/PerpsTile';
 
 // images
 import PillarXLogo from './components/PillarXLogo/PillarXLogo';
@@ -382,6 +383,7 @@ const App = () => {
         className="flex flex-col gap-[40px] tablet:gap-[28px] mobile:gap-[32px]"
       >
         <WalletPortfolioTile />
+        <PerpsTile />
         {DisplayHomeFeedTiles}
         {(isHomeFeedFetching || isHomeFeedLoading) && page === 1 && (
           <>


### PR DESCRIPTION
- Created new PerpsTile component with gradient background
- Added tile to homefeed after WalletPortfolioTile
- Tile navigates to /perps app
- Fixed WalletPortfolioBalance tests (mocked AccountSelector)
- Fixed lint errors (button type, unused imports)
- Updated test snapshots

## Description
<!--- Provide a general summary of your changes in the Title above -->
-

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added account selector dropdown in the header, allowing users to switch between Smart Account and EOA with portfolio balances and address copy functionality.
  * Introduced new Perps tile in the home feed for quick navigation to perpetuals trading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->