### PR TITLE
ci: fix CircleCI apt + Slack notification hard-fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ jobs:
       - run:
           name: Install jq
           command: |
+            # Cypress image ships a Google Chrome apt source whose GPG key can expire
+            # and make `apt-get update` fail with NO_PUBKEY / exit 100 before jq installs.
+            rm -f /etc/apt/sources.list.d/google-chrome*.list /etc/apt/sources.list.d/*chrome*.list || true
             apt-get update && apt-get install -y curl jq
 
       # Clone secondary repo and run Playwright tests

--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -7,6 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Send Slack deployment notifications
+      continue-on-error: true
       uses: arddluma/cloudflare-pages-slack-notification@v4
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}


### PR DESCRIPTION
## Summary
- CircleCI e2e was dying at `Install jq` because `apt-get update` fails on the Cypress image's Chrome apt source (`NO_PUBKEY FD533C07C264648F`). Remove those sources before updating.
- Slack/Cloudflare Pages notification job was failing the `build` check with Cloudflare API auth error `10000`. Mark that step `continue-on-error: true` so a bad/expired `CF_API_TOKEN` does not block releases (token still needs rotation in repo secrets).

## Test plan
- [ ] CircleCI e2e on staging gets past Install jq
- [ ] Notifications workflow no longer fails the commit status when CF auth errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline stability and workflow reliability to enhance deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->